### PR TITLE
Modify brokenState and ways of extracting pname&version in ETL process

### DIFF
--- a/etl/etl.py
+++ b/etl/etl.py
@@ -86,7 +86,7 @@ def unique_insert_node(g, row):
         .property("pname", row["pname"])
         .property("name", row["name"])
         .property("version", row["version"])
-        .property("brokenState", str(row["brokenState"]))
+        .property("brokenState", row["brokenState"])
         .property("license", row["license"]),
     ).iterate()
 

--- a/etl/etl.py
+++ b/etl/etl.py
@@ -86,7 +86,7 @@ def unique_insert_node(g, row):
         .property("pname", row["pname"])
         .property("name", row["name"])
         .property("version", row["version"])
-        .property("brokenState", row["brokenState"])
+        .property("brokenState", str(row["brokenState"]))
         .property("license", row["license"]),
     ).iterate()
 

--- a/etl/nixpkgs-graph.nix
+++ b/etl/nixpkgs-graph.nix
@@ -31,9 +31,15 @@ let
           inherit path;
           # can't name it `outPath` because serialization would only output it instead of dict
           # see Nix `toString` docs
-          pname = (builtins.tryEval (if okValue ? pname then okValue.pname else "")).value;
-          version = (builtins.tryEval (if okValue ? version then okValue.version else "")).value;
+          # we don't query pname and version directly because some derivations only have a `name` attribute.
+          # use `builtins.parseDrvName` to get the name on all cases
           name = (builtins.tryEval (if okValue ? name then okValue.name else "")).value;
+          pname = (builtins.tryEval (if okValue ? name && okValue.name != false
+                                     then (builtins.parseDrvName okValue.name).name
+                                     else "")).value;
+          version = (builtins.tryEval (if okValue ? name && okValue.name != false
+                                       then (builtins.parseDrvName okValue.name).version
+                                       else "")).value;
           brokenState = (builtins.tryEval (if okValue ? meta.broken then okValue.meta.broken else "")).value;
           license = (builtins.tryEval (if okValue ? meta.license.fullName then okValue.meta.license.fullName else "")).value;
           outputPath =

--- a/etl/nixpkgs-graph.nix
+++ b/etl/nixpkgs-graph.nix
@@ -40,7 +40,7 @@ let
           version = (builtins.tryEval (if okValue ? name && okValue.name != false
                                        then (builtins.parseDrvName okValue.name).version
                                        else "")).value;
-          brokenState = (builtins.tryEval (if okValue ? meta.broken then okValue.meta.broken else "")).value;
+          brokenState = (builtins.tryEval (if okValue ? meta.broken then okValue.meta.broken else false)).value;
           license = (builtins.tryEval (if okValue ? meta.license.fullName then okValue.meta.license.fullName else "")).value;
           outputPath =
             let


### PR DESCRIPTION
Here are two minor changes in the ETL process.
- For some packages, the `brokenState` of them is an empty string `''`, which conflicts with the `boolean` format, so we turn the `brokenState` property into `str`.
- Suggested by @jlesquembre's talk with nix group: The queries use `pname` and `version`, but some derivations only have a `name` attribute. We use nix builtin function `builtins.parseDrvName` to get the name on all cases.
