### PR TITLE
ETL container: add nix binary to PATH

### DIFF
--- a/etl/Dockerfile
+++ b/etl/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /code
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
+RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux --init none --no-confirm
+ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 
 # if you use an alpine python image, the following is necessary
 # RUN apk add --no-cache gcc musl-dev linux-headers

--- a/etl/README.md
+++ b/etl/README.md
@@ -1,3 +1,28 @@
 # etl
 
 Scripts for populating a Gremlin database with nixpkgs graph data.
+
+## Installation
+
+Ensure python 3 is installed then install the required python dependencies with
+something like:
+
+```
+pip install -r etl/requirements.txt
+```
+
+And then run the script:
+
+```
+python etl/example_query.py
+```
+
+## Docker
+
+You can use docker to run the etl script:
+
+```bash
+cd etl
+docker build -t etl .
+docker run --rm -it --name=etl --network=host etl python etl.py
+```


### PR DESCRIPTION
fixes #32 

See https://github.com/DeterminateSystems/nix-installer#in-a-container

I think it worked for me because I executed the command from the container in a bash session (by default the container runs `/bin/sh`, and nix is not in the PATH)

