### PR TITLE
Extract data for any flake

### DIFF
--- a/etl/nixpkgs-graph.nix
+++ b/etl/nixpkgs-graph.nix
@@ -2,7 +2,7 @@
 # NIXPKGS_ALLOW_BROKEN=1 NIXPKGS_ALLOW_INSECURE=1 TARGET_FLAKE_REF="github:nixos/nixpkgs/master" TARGET_SYSTEM="x86_64-linux" nix eval --json --file "./nixpkgs-graph.nix"
 
 let
-  pkgs = builtins.getFlake "nixpkgs";
+  nixpkgs = builtins.getFlake "nixpkgs";
   targetFlakeRef = builtins.getEnv "TARGET_FLAKE_REF";
   # We specify the system of the target here to avoid ambiguity
   # The outputs of a flake will produce different results on every system
@@ -14,7 +14,7 @@ let
       flake.outputs.packages.${targetSystem} or flake.outputs.defaultPackage.${targetSystem} or flake.outputs.legacyPackages.${targetSystem} or { };
 in
 
-with pkgs.lib;
+with nixpkgs.lib;
 
 let
   recurse =

--- a/etl/nixpkgs-graph.nix
+++ b/etl/nixpkgs-graph.nix
@@ -6,12 +6,12 @@ let
   targetFlakeRef = builtins.getEnv "TARGET_FLAKE_REF";
   # We specify the system of the target here to avoid ambiguity
   # The outputs of a flake will produce different results on every system
-  targetSys = builtins.getEnv "TARGET_SYSTEM";
+  targetSystem = builtins.getEnv "TARGET_SYSTEM";
   targetFlakePkgs =
     let
       flake = builtins.getFlake targetFlakeRef;
     in
-      flake.outputs.packages.${targetSys} or flake.outputs.defaultPackage.${targetSys} or flake.outputs.legacyPackages.${targetSys} or { };
+      flake.outputs.packages.${targetSystem} or flake.outputs.defaultPackage.${targetSystem} or flake.outputs.legacyPackages.${targetSystem} or { };
 in
 
 with pkgs.lib;


### PR DESCRIPTION
This PR modifies the process of extracting of nix data by allowing that we can input a specific flake and scan for all available packages in `nixpkgs` to get the raw data of the flake.

The attribute of the flake outputs can be `packages`, `defaultPackage` or `legacyPackages`, and we've covered these three situations. If none of these attributes are in the outputs, we will get a blank list.
We need to specify the system of the flake to get the data via `TARGET_FLAKE_SYSTEM`.

For example, for the whole `nixpkgs` repo, we can use 
```
NIXPKGS_ALLOW_BROKEN=1 NIXPKGS_ALLOW_INSECURE=1 TARGET_FLAKE_REF="github:nixos/nixpkgs/master" TARGET_FLAKE_SYSTEM="x86_64-linux" nix eval --json --file "./nixpkgs-graph.nix"
```

Fixes #47 