### PR TITLE
Add CI checks

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -1,0 +1,25 @@
+name: CI Frontend
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "web/**"
+  pull_request:
+    paths:
+      - "web/**"
+
+jobs:
+  build:
+    name: Frontend Prod build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: cachix/install-nix-action@v19
+
+      - run: nix develop --command check-prettier
+
+      - name: Prod build (docker)
+        run: docker build -t nixpkgs-graph-explorer_web web

--- a/.gitignore
+++ b/.gitignore
@@ -163,8 +163,10 @@ cython_debug/
 # NodeJS stuff
 node_modules
 __previewjs__
-.vite 
+.vite
 web/types
+web/dist
+web/public/assets/*
 
 # direnv
 .direnv

--- a/flake.nix
+++ b/flake.nix
@@ -39,8 +39,6 @@
 
             poetry
             python
-            black
-            isort
 
             nixpkgs-fmt
           ];
@@ -84,9 +82,9 @@
                 help = "Format Python code";
                 command = ''
                   echo 'Formatting code with black...'
-                  black .
+                  poetry run black .
                   echo 'Formatting imports with isort...'
-                  isort .
+                  poetry run isort .
                 '';
                 category = "Python";
               }
@@ -94,8 +92,8 @@
                 name = "check-python";
                 help = "Check Python formatting";
                 command = ''
-                  black --check .
-                  isort --check-only .
+                  poetry run black --check .
+                  poetry run isort --check-only .
                 '';
                 category = "Python";
               }

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,8 @@
           inherit system;
           overlays = [ pythonOverlay inputs.devshell.overlay ];
         };
-
-      in {
+      in
+      {
         devShells.default = pkgs.devshell.mkShell {
           motd = ''
             nixpkgs-graph-explorer development shell{reset}
@@ -33,69 +33,130 @@
 
           env = [ ];
 
-          packages = with pkgs; [ nodejs-19_x poetry python nixfmt ];
-          commands = [
-            ##################################################################
-            # Typescript commands
-            ##################################################################
-            # TODO: Add these
-            ##################################################################
-            # Python-specific commands
-            ##################################################################
-            {
-              name = "format-python";
-              help = "Format Python code";
-              command = ''
-                echo 'Formatting code with black...'
-                poetry run black .
-                echo 'Formatting imports with isort...'
-                poetry run isort .
-              '';
-              category = "Python";
-            }
-            {
-              name = "check-python";
-              help = "Check Python formatting";
-              command = ''
-                poetry run black --check .
-                poetry run isort --check-only .
-              '';
-               category = "Python";
-            }
-            {
-              name = "lint-python";
-              help = "Lint Python code";
-              command = ''
-                poetry run flake8 .
-                poetry run pyright .
-              '';
-               category = "Python";
-            }
-            ##################################################################
-            # Project-wide commands
-            ##################################################################
-            {
-              name = "format";
-              help = "Format code for entire project";
-              command = ''
-                format-python
-              '';
-            }
-            {
-              name = "check";
-              help = "Check formatting for entire project";
-              command = ''
-                check-python
-              '';
-            }
-            {
-              name = "lint";
-              help = "Lint entire project";
-              command = ''
-                lint-python
-              '';
-            }
+          packages = with pkgs; [
+            nodejs-19_x
+            nodePackages.prettier
+
+            poetry
+            python
+            black
+            isort
+
+            nixpkgs-fmt
           ];
+          commands =
+            let
+              prettierCmd =
+                ''
+                  prettier \
+                    --prose-wrap always \
+                    --loglevel warn \
+                    --ignore-path .gitignore \
+                '';
+            in
+            [
+              ##################################################################
+              # Frontend commands
+              ##################################################################
+              {
+                name = "format-prettier";
+                help = "Format frontend code";
+                command = ''
+                  echo 'Formatting code with prettier...'
+                  ${prettierCmd} --write web
+                '';
+                category = "Frontend";
+              }
+              {
+                name = "check-prettier";
+                help = "Check Prettier formatting";
+                command = ''
+                  ${prettierCmd} --check web
+                '';
+                category = "Frontend";
+              }
+
+              ##################################################################
+              # Python-specific commands
+              ##################################################################
+              {
+                name = "format-python";
+                help = "Format Python code";
+                command = ''
+                  echo 'Formatting code with black...'
+                  black .
+                  echo 'Formatting imports with isort...'
+                  isort .
+                '';
+                category = "Python";
+              }
+              {
+                name = "check-python";
+                help = "Check Python formatting";
+                command = ''
+                  black --check .
+                  isort --check-only .
+                '';
+                category = "Python";
+              }
+              {
+                name = "lint-python";
+                help = "Lint Python code";
+                command = ''
+                  poetry run flake8 .
+                  poetry run pyright .
+                '';
+                category = "Python";
+              }
+              ##################################################################
+              # Nix-specific commands
+              ##################################################################
+              {
+                name = "format-nix";
+                help = "Format Nix code";
+                command = ''
+                  echo 'Formatting code with nixpkgs-fmt...'
+                  nixpkgs-fmt .
+                '';
+                category = "Nix";
+              }
+              {
+                name = "check-nix";
+                help = "Check Nix formatting";
+                command = ''
+                  nixpkgs-fmt --check .
+                '';
+                category = "Nix";
+              }
+              ##################################################################
+              # Project-wide commands
+              ##################################################################
+              {
+                name = "format";
+                help = "Format code for entire project";
+                command = ''
+                  format-python
+                  format-prettier
+                  format-nix
+                '';
+              }
+              {
+                name = "check";
+                help = "Check formatting for entire project";
+                command = ''
+                  check-python
+                  check-prettier
+                  check-nix
+                '';
+              }
+              {
+                name = "lint";
+                help = "Lint entire project";
+                command = ''
+                  lint-python
+                '';
+              }
+            ];
         };
       });
 }

--- a/web/src/app-main.ts
+++ b/web/src/app-main.ts
@@ -9,7 +9,6 @@ import SlDrawer from "@shoelace-style/shoelace/dist/components/drawer/drawer.js"
 
 import type { ClickItemPayload } from "./nix-search";
 import "./nix-search.ts";
-import "./logos/graph-logo";
 
 import dagre from "cytoscape-dagre";
 import cytoscape from "cytoscape";


### PR DESCRIPTION
In my last PR, a small issue went unnoticed. I fixed it, and added some CI checks.

For now, only the frontend part is checked, we can add more checks in another PR.

Some additional changes I did, which are open to discussion:

- Add check/format-nix commands, but replaced `nixfmt` with `nixpkgs-fmt`. I personally don't prefer one over the other, but the CLI interface for `nixpkgs-fmt` is nicer. You can check/format all nix files at once. `nixfmt` doesn't offer a bulk option.
- Replaced `poetry run black/isort ...` with `black/isort ...`. Those binaries are provided by nixpkgs, that way we can skip the `poetry install ...` command, and auto-format the `etl` sub-project too 