### PR TITLE
Add custom gremlin transport

### DIFF
--- a/api/explorer/api/__init__.py
+++ b/api/explorer/api/__init__.py
@@ -11,6 +11,7 @@ from gremlin_python.driver.driver_remote_connection import DriverRemoteConnectio
 from pydantic import BaseModel
 from starlette.applications import Starlette
 
+from explorer.api.gremlin import WebSocketTransport, default_remote_connection
 from explorer.api.queries.packages import (
     ListPackagesRequest,
     ListPackagesResponse,
@@ -61,11 +62,11 @@ async def lifespan(_app: Starlette) -> AsyncGenerator[State, None]:
         READ_ONLY_TRAVERSAL_SOURCE,
         pool_size=4,
         message_serializer=serializer.GraphSONMessageSerializer(),
+        transport_factory=WebSocketTransport,
     )
-    gremlin_remote_connection = DriverRemoteConnection(
+    gremlin_remote_connection = default_remote_connection(
         gremlin_url,
         READ_ONLY_TRAVERSAL_SOURCE,
-        message_serializer=serializer.GraphSONMessageSerializer(),
     )
     yield {
         "gremlin_client": gremlin_client,

--- a/api/explorer/api/gremlin.py
+++ b/api/explorer/api/gremlin.py
@@ -1,0 +1,181 @@
+"""Utilities for working with Gremlin Server"""
+
+
+from ssl import SSLContext
+from typing import Any, Callable, TypeVar
+
+import backoff
+from gremlin_python.driver import serializer
+from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
+from gremlin_python.driver.transport import AbstractBaseTransport
+from websockets.exceptions import ConnectionClosedError
+from websockets.sync import client
+from websockets.typing import LoggerLike
+
+
+class GremlinTransportError(Exception):
+    """Indicates an error in the Gremlin transport"""
+
+
+def default_remote_connection(
+    url: str, traversal_source: str = "g"
+) -> DriverRemoteConnection:
+    """Creates a Gremlin remote connection using the `nixpkgs-graph-explorer` defaults
+
+    Args:
+        url (str): The url of the Gremlin Server to connect to
+        traversal_source (str, optional): The name of the graph traversal source to
+            use. Note that this is expected to be pre-configured on the target
+            Gremlin Server. Defaults to "g".
+
+    Returns:
+        DriverRemoteConnection: the remote connection
+    """
+    return DriverRemoteConnection(
+        url,
+        traversal_source,
+        message_serializer=serializer.GraphSONMessageSerializer(),
+        transport_factory=WebSocketTransport,
+    )
+
+
+class WebSocketTransport(AbstractBaseTransport):
+    """
+    An alternative to `gremlinpython`'s `AiohttpTransport` with more
+    robust error handling. Built using `websocket`.
+    """
+
+    def __init__(
+        self,
+        max_retries: int = 3,
+        read_timeout=30,
+        ssl_context: SSLContext | None = None,
+        open_timeout: float | None = 10,
+        close_timeout: float | None = 10,
+        logger: LoggerLike | None = None,
+    ) -> None:
+        """Initializes the transport.
+
+        No connections are opened until connect() is called.
+
+        Args:
+            max_retries (int, optional): The maximum number of times to reconnect and
+                retry IO operations in case of connection errors. Defaults to 3.
+            read_timeout (int, optional): Timeout for read operations, in seconds.
+                Defaults to 30.
+            ssl_context (SSLContext | None, optional): An optional SSL context to
+                provide to the websocket client. Defaults to None.
+            open_timeout (float | None, optional): Timeout for opening client
+                connections, in seconds. Defaults to 10.
+            close_timeout (float | None, optional): Timeout for closing client
+                connections, in seconds. Defaults to 10.
+            logger (LoggerLike | None, optional): Optional logger to pass to the
+                underlying websocket client. If unspecified the default one specified
+                by the websocket library will be used. Defaults to None.
+        """
+        self.max_retries = max_retries
+        self.ssl_context = ssl_context
+        self.open_timeout = open_timeout
+        self.close_timeout = close_timeout
+        self.connection_logger = logger
+        self.read_timeout = read_timeout
+        self._client: client.ClientConnection | None = None
+        self._last_connect_url: str | None = None
+        self._last_connect_headers: dict | None = None
+
+    def unsafe_get_client(self) -> client.ClientConnection:
+        """Gets the transport's current websocket client connection
+
+        Raises:
+            GremlinTransportError: If a client has not yet been created using connect()
+
+        Returns:
+            ClientConnection: the websocket client connection
+        """
+        if self._client is None:
+            raise GremlinTransportError(
+                "WebSocketTransport.unsafe_get_client() was called, but no client has "
+                "configured. Make sure that connect() is called before this method."
+            )
+        return self._client
+
+    @backoff.on_exception(backoff.expo, OSError, max_tries=3)
+    def connect(self, url: str, headers: dict | None = None) -> None:
+        """Initializes the websocket client if one does not already exist.
+
+        Args:
+            url (str): The url of the websocket server.
+            headers (dict | None, optional): Extra HTTP headers to include in
+                requests. Defaults to None.
+        """
+        if self._client is None:
+            self._client = client.connect(
+                uri=url,
+                additional_headers=headers,
+                open_timeout=self.open_timeout,
+                close_timeout=self.close_timeout,
+                ssl_context=self.ssl_context,
+                logger=self.connection_logger,
+            )
+            self._last_connect_url = url
+            self._last_connect_headers = headers
+
+    @property
+    def with_reconnect(self) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """
+        A decorator which will retry its input function with exponential back-off
+        if unexpected websocket connection errors are raised.
+
+        Raises:
+            GremlinTransportError: If connect() has not already been called at
+                least once.
+        """
+        if self._last_connect_url is None:
+            raise GremlinTransportError(
+                "Attempted to define a with_reconnect instance, however no "
+                "previously used url was found. This should not be possible. Ensure "
+                "that connect() has been called at least once before calling this "
+                " method."
+            )
+        return backoff.on_exception(
+            backoff.expo,
+            ConnectionClosedError,
+            max_tries=self.max_retries,
+            on_backoff=self.connect(self._last_connect_url, self._last_connect_headers),
+        )
+
+    def write(self, message: bytes) -> None:
+        """Writes data to the current client connection
+
+        Args:
+            message (bytes): The data to write
+        """
+        # Note: we apply the decorator in an anonymous function here so that we can
+        # reference `self` for attempting reconnects
+        self.with_reconnect(lambda: self.unsafe_get_client().send(message))()
+
+    def read(self) -> bytes:
+        """Reads the next message from the current client connection
+
+        Returns:
+            bytes: The message data. If the server returned text data it will be
+                encoded as a UTF-8 string.
+        """
+        data = self.with_reconnect(
+            lambda: self.unsafe_get_client().recv(timeout=self.read_timeout)
+        )()
+        # Note: Mimicking gremlinpython's approach to homogenizing the output type here
+        if isinstance(data, str):
+            data = data.strip().encode("utf-8")
+        return data
+
+    def close(self) -> None:
+        """Closes the websocket client, if one exists."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    @property
+    def closed(self) -> bool:
+        """Flag indicating whether the transport's websocket client has been closed"""
+        return self._client is None

--- a/api/explorer/api/gremlin.py
+++ b/api/explorer/api/gremlin.py
@@ -101,13 +101,20 @@ class WebSocketTransport(AbstractBaseTransport):
 
     @backoff.on_exception(backoff.expo, OSError, max_tries=3)
     def connect(self, url: str, headers: dict | None = None) -> None:
-        """Initializes the websocket client if one does not already exist.
+        """Initializes the websocket client, closing the current client if one exists
 
         Args:
             url (str): The url of the websocket server.
             headers (dict | None, optional): Extra HTTP headers to include in
                 requests. Defaults to None.
         """
+
+        # Note: this approach of allowing connect() calls even if a client already
+        # exists is a bit nonstandard but follows the apparent semantics of
+        # gremlinpython's transport API.
+        #
+        # See this discussion on GitHub for more details:
+        # https://github.com/tweag/nixpkgs-graph-explorer/pull/74#discussion_r1170033067
         if self._client is not None:
             self.close()
 

--- a/api/explorer/api/gremlin.py
+++ b/api/explorer/api/gremlin.py
@@ -2,7 +2,7 @@
 
 
 from ssl import SSLContext
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable
 
 import backoff
 from gremlin_python.driver import serializer

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -4,12 +4,11 @@ from typing import Callable, Iterable, TypeVar
 
 import click
 from explorer.core import model
-from gremlin_python.driver import serializer
-from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.process.graph_traversal import GraphTraversalSource
 
 from explorer.api import graph
+from explorer.api.gremlin import default_remote_connection
 
 logger = logging.getLogger(__name__)
 
@@ -231,11 +230,7 @@ def main(graph_json: str, gremlin_server: str, gremlin_source: str):
 
     click.echo("Configuring connection to Gremlin Server...")
     with closing(
-        DriverRemoteConnection(
-            gremlin_server,
-            gremlin_source,
-            message_serializer=serializer.GraphSONMessageSerializer(),
-        )
+        default_remote_connection(gremlin_server, traversal_source=gremlin_source)
     ) as remote:
         g = traversal().with_remote(remote)
         click.echo("Done.")

--- a/api/explorer/api/queries/test/test_query.py
+++ b/api/explorer/api/queries/test/test_query.py
@@ -1,5 +1,4 @@
 import pytest
-from gremlin_python.driver import serializer
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 from gremlin_python.process.anonymous_traversal import traversal
 
@@ -10,6 +9,7 @@ from explorer.api.graph import (
     insert_unique_directed_edge,
     insert_unique_vertex,
 )
+from explorer.api.gremlin import default_remote_connection
 from explorer.api.queries.cytoscape import (
     CytoscapeJs,
     EdgeData,
@@ -35,10 +35,9 @@ EDGES = [
 
 @pytest.fixture
 def graph_connection():
-    conn = DriverRemoteConnection(
-        "ws://localhost:8182/gremlin",
-        "g",
-        message_serializer=serializer.GraphSONMessageSerializer(),
+    # FIXME: use a traversal_source purely dedicated to tests
+    conn = default_remote_connection(
+        "ws://localhost:8182/gremlin", traversal_source="g"
     )
     g = traversal().with_remote(conn)
     # Insert package vertices

--- a/api/explorer/api/test/test_graph.py
+++ b/api/explorer/api/test/test_graph.py
@@ -1,11 +1,11 @@
 from typing import Any, Mapping, cast
 
 import pytest
-from gremlin_python.driver import serializer
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 from gremlin_python.process.anonymous_traversal import traversal
 
 from explorer.api.graph import ElementId, GraphElement, UniqueGraphElement
+from explorer.api.gremlin import default_remote_connection
 
 
 class DummyGraphElement(GraphElement):
@@ -62,10 +62,9 @@ class DummyEdgeNoProps(GraphElement):
 
 @pytest.fixture
 def graph_connection():
-    conn = DriverRemoteConnection(
-        "ws://localhost:8182/gremlin",
-        "g",
-        message_serializer=serializer.GraphSONMessageSerializer(),
+    # FIXME: use a traversal_source purely dedicated to tests
+    conn = default_remote_connection(
+        "ws://localhost:8182/gremlin", traversal_source="g"
     )
     g = traversal().with_remote(conn)
     yield conn

--- a/api/explorer/api/test/test_gremlin.py
+++ b/api/explorer/api/test/test_gremlin.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock, patch
+
+from websockets.exceptions import ConnectionClosedError
+
+
+def test_unit_write_reconnects():
+    """
+    Check that writing to a connection which has been closed will trigger an
+    expected number of reconnect attempts
+    """
+    from explorer.api.gremlin import WebSocketTransport
+
+    MockClientConnection = MagicMock()
+    MockClientConnection.return_value.send.side_effect = [
+        ConnectionClosedError(None, None),
+        ConnectionClosedError(None, None),
+        None,
+    ]
+    mock_connect = MagicMock()
+    mock_connect.return_value = MockClientConnection()
+
+    with patch("websockets.sync.client.connect", new=mock_connect):
+        transport = WebSocketTransport(max_retries=2)
+        transport.connect("ws://mock_url")
+
+        result = transport.write(b"foobar")
+
+        assert result is None
+        assert mock_connect.return_value.send.call_count == 3
+        assert mock_connect.call_count == 3
+
+
+def test_unit_read_reconnects():
+    """
+    Check that reading from a connection which has been closed will trigger an
+    expected number of reconnect attempts
+    """
+    from explorer.api.gremlin import WebSocketTransport
+
+    MockClientConnection = MagicMock()
+    # Note: calling the mocked recv() will result in a ConnectionClosedError twice then
+    # successfully return data.
+    mock_data = b"foo"
+    MockClientConnection.return_value.recv.side_effect = [
+        ConnectionClosedError(None, None),
+        ConnectionClosedError(None, None),
+        b"foo",
+    ]
+    mock_connect = MagicMock()
+    mock_connect.return_value = MockClientConnection()
+
+    with patch("websockets.sync.client.connect", new=mock_connect):
+        transport = WebSocketTransport(max_retries=2)
+        transport.connect("ws://mock_url")
+
+        result = transport.read()
+
+        assert result == mock_data
+        assert mock_connect.return_value.recv.call_count == 3
+        assert mock_connect.call_count == 3

--- a/api/explorer/api/test/test_ingest.py
+++ b/api/explorer/api/test/test_ingest.py
@@ -1,10 +1,10 @@
 import pytest
 from explorer.core import model
-from gremlin_python.driver import serializer
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 from gremlin_python.process.anonymous_traversal import traversal
 
 from explorer.api import graph
+from explorer.api.gremlin import default_remote_connection
 
 #######################################################################################
 # Mock Data
@@ -72,12 +72,9 @@ dummy_nix_graph = model.NixGraph(packages=[dummy_pkg_a])
 #######################################################################################
 @pytest.fixture
 def graph_connection():
-    conn = DriverRemoteConnection(
-        "ws://localhost:8182/gremlin",
-        # name of the graph
-        # FIXME use a graph purely dedicated to tests
-        "g",
-        message_serializer=serializer.GraphSONMessageSerializer(),
+    # FIXME: use a traversal_source purely dedicated to tests
+    conn = default_remote_connection(
+        "ws://localhost:8182/gremlin", traversal_source="g"
     )
     g = traversal().with_remote(conn)
     yield conn

--- a/api/explorer/api/test/test_packages.py
+++ b/api/explorer/api/test/test_packages.py
@@ -1,10 +1,9 @@
 import pytest
-from gremlin_python.driver import serializer
-from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 from gremlin_python.process.anonymous_traversal import traversal
 
 import explorer.api.queries.packages as packages
 from explorer.api.graph import Package, insert_unique_vertex
+from explorer.api.gremlin import default_remote_connection
 from explorer.api.queries.pagination import Cursor, CursorDirection
 
 PACKAGE_A = Package(pname="package-a", outputPath="a/a/a")
@@ -17,10 +16,9 @@ DUMMY_PACKAGES = [PACKAGE_A, PACKAGE_B, PACKAGE_C, PACKAGE_AA]
 
 @pytest.fixture
 def graph_connection():
-    conn = DriverRemoteConnection(
-        "ws://localhost:8182/gremlin",
-        "g",
-        message_serializer=serializer.GraphSONMessageSerializer(),
+    # FIXME: use a traversal_source purely dedicated to tests
+    conn = default_remote_connection(
+        "ws://localhost:8182/gremlin", traversal_source="g"
     )
     g = traversal().with_remote(conn)
     # Insert test dataset

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -175,6 +175,18 @@ tests = ["attrs[tests-no-zope]", "zope.interface"]
 tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy (>=0.971,<0.990)", "mypy (>=0.971,<0.990)", "pympler", "pympler", "pytest (>=4.3.0)", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-mypy-plugins", "pytest-xdist[psutil]", "pytest-xdist[psutil]"]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
+    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
+]
+
+[[package]]
 name = "black"
 version = "23.3.0"
 description = "The uncompromising code formatter."
@@ -1224,82 +1236,82 @@ anyio = ">=3.0.0"
 
 [[package]]
 name = "websockets"
-version = "11.0"
+version = "11.0.1"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "websockets-11.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:269e3547877a6ca55f62acdf291b256b01bc3469535e892af36afd3e17de284a"},
-    {file = "websockets-11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:70a4e03d2416c1dad16ccfab97c975192337c6481b07167c90221f1926893e1e"},
-    {file = "websockets-11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4100dc8566ea3b9c0528dee73284be524ab053aebd77e3fc7439a90e0d57745b"},
-    {file = "websockets-11.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8e0505c556b2b48078291b300d930f2fb8ba81d1e36379b637c060cfa561ae4"},
-    {file = "websockets-11.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d5bc68cec8269b4b52ab6d1d8690f56dba35f7bcb83a5487518406300f81cf1"},
-    {file = "websockets-11.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:067ac1f6153fc5218afc4563491dcbdb7384895cfc588a0afee962ca77fe0b58"},
-    {file = "websockets-11.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:910c84c0cfe4f872905b6ebe1866c579582070331abcb7a58621935eca95c18a"},
-    {file = "websockets-11.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:df0f7769450ca67a53182f917910e2b0b6dd3f8268f88cbfe54ee6be96812889"},
-    {file = "websockets-11.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fe23605f5c351773b6fb82fcf680549980d63e126fab5213ed875686c0cec25d"},
-    {file = "websockets-11.0-cp310-cp310-win32.whl", hash = "sha256:eb2e7cd654a05c36fccf726385c64a0e1027997d05ba0859f4d84c3d87db1623"},
-    {file = "websockets-11.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb26c333751a1e3805ecc416a85dcfa3657676b185acd515fd6992f0cea898ef"},
-    {file = "websockets-11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b4a939963bae1055f14976ef2cf53e797c1997f8835ca9cf23060afc3e7d6718"},
-    {file = "websockets-11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d7fc189fb632f8b31af8a5b32105919662a1bbaac20912320482415b7fed9c96"},
-    {file = "websockets-11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6e3cfc890f1326c95fd7d4cc50f2bd496d3f014fb2da36b4525a10f226be565d"},
-    {file = "websockets-11.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9093f4c72c23ed5e475970c6a37e77c4f3a8856223421b9eb405b9fb2170629f"},
-    {file = "websockets-11.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5c56547f97bc76293522ccfcfbdde12442420f1a2c0218ff45d733a0030046df"},
-    {file = "websockets-11.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffb406b4449d4fa41ebc47faa3b9153a082f6fe0e4a0891f596a5ddb69fdeccd"},
-    {file = "websockets-11.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8fad76be2c5e36fb3620ad507ac8004e9f358f5c4a9a1b756dbe7918d58884a0"},
-    {file = "websockets-11.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:17eb1988d320e2f1f20e4a3523f1068a0bb08318ab123962fc99fd90c90ab0d6"},
-    {file = "websockets-11.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9873288db9c673a2ba9c0f7b59a130576c50fc75f3336a706fff686009c41631"},
-    {file = "websockets-11.0-cp311-cp311-win32.whl", hash = "sha256:cf4ef6343478bf63098d3060fe06baf54d9c011b4b1b05e65e7957091cc87ef4"},
-    {file = "websockets-11.0-cp311-cp311-win_amd64.whl", hash = "sha256:713cd5fc1fd40436495c90a259274e1a4a39416c65447a256434941ddaf2f424"},
-    {file = "websockets-11.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:649ddddcbafd318d427b843425c92b1c035660c32507645c472c77356226cf07"},
-    {file = "websockets-11.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:564c53d84b95da527e96778f2cc873ef186038924abee601f9e8f12ebda9ad46"},
-    {file = "websockets-11.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66d8df2db9801063e4093efe01458b1705c9f76382ad32617c005eeeb201a730"},
-    {file = "websockets-11.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbcd876ed166a82d250fcf012b729315489e9d653cb659c2e013c19daba2eb8f"},
-    {file = "websockets-11.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:cb00963b49d343210ebbdbe69a35004fbecad73da2158e83d481cd2a6716cf19"},
-    {file = "websockets-11.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:3d6f7c2f822e439f47f3492ee3e48c87c7d134d619a42c6dba1a318504501bfb"},
-    {file = "websockets-11.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c4b2ae9c0f1acec5d2f8000eb496eebb9db19055a63716ee166cf0694b945982"},
-    {file = "websockets-11.0-cp37-cp37m-win32.whl", hash = "sha256:2b363e0f9b4247a0c7482e22c70ef39fb3259a14f7c0791c9200b93145f60b4b"},
-    {file = "websockets-11.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3d372c3426f165a0a22be9250526b1cd12e3556e80b4b2afaa6fd6649c99b086"},
-    {file = "websockets-11.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:7eb914d37e0574246c63b995f9ca8d7bb7c2f2d53a8d4e9b00200ea856aa43c4"},
-    {file = "websockets-11.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a8717a5f3a00cde308e2971064bd5fcb14e0cc08f8234b97f4eb92b505ea95d4"},
-    {file = "websockets-11.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a17151722349c4af221616cca2f28e79237738bfbc53e7155240e2a8a7cc02f4"},
-    {file = "websockets-11.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a4b60686d9b2ba500847c045595eb5887f4cca7102b4615773b6f490aa611107"},
-    {file = "websockets-11.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eededf25ef6b838e650eeeb1511804b82e9ece566fe6cdc11aa909d2992dcdaf"},
-    {file = "websockets-11.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7587f339f016f0e1b0b6f013e98c83e382c5929774f2b8234c1b2d3f01dd1339"},
-    {file = "websockets-11.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:26369646078e16e7364729ed3e3b1a4315ab1a22ca3c48b4e25dea48fcc1a881"},
-    {file = "websockets-11.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:92f51fbe87381ff76c1791dd44d599152b400f1adfa8453613f1ff6857200ee7"},
-    {file = "websockets-11.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b5bb04a77c326d727c0b986c37a76147916d79db95629267307d1be47788a020"},
-    {file = "websockets-11.0-cp38-cp38-win32.whl", hash = "sha256:50ac95111009178e58b9a25aa51702cdaad4ed843b98eb9b58d69b323ccb224e"},
-    {file = "websockets-11.0-cp38-cp38-win_amd64.whl", hash = "sha256:7a4076cd6a3678def988668fc4b1779da598e1e5c9fa26319af5499f00c23e1c"},
-    {file = "websockets-11.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:26559e8a385f71ce2a58f3bb1d005ddd3db7d3328ddbfbff1034f4039d46c4ec"},
-    {file = "websockets-11.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f10d283697dec8d91fa983eb8e217c9cac27bc1032057768129b89780009318e"},
-    {file = "websockets-11.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f74efe229e078bf5595e207e9a7b135ff37a10858263ed86be66003c4c98d47b"},
-    {file = "websockets-11.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f048c88bfcc5bf0e038630cfb970b2c479f913819fd9653db920eef3b105a2b1"},
-    {file = "websockets-11.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ceab6c1827fa14ad10c6b0806941d577b21d17012a3648787ac2b946182285b4"},
-    {file = "websockets-11.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:817227e23897808c4bb621da7f57b1f83ee18345bdc44f5c9c1bbd3a094a73f6"},
-    {file = "websockets-11.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6fdcc17348d8697c1f88bba38680cca94131f2a9db727a61fe067284e1e59e8d"},
-    {file = "websockets-11.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:8b21ad915b747075f29fe2fa5590111d98988d6730d2cd212acfe52bbe6a2545"},
-    {file = "websockets-11.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9ae401ad881d5329062b9b2d8160f0b2a147430974f2a3f32e6cedadddc2d634"},
-    {file = "websockets-11.0-cp39-cp39-win32.whl", hash = "sha256:ee84660927293f449760badfe010e06409edb99d72e1910e2e404d2eeff6990f"},
-    {file = "websockets-11.0-cp39-cp39-win_amd64.whl", hash = "sha256:2b4e704a9dac1faf4994e63dceae9e2f504913ff0f865bd3e5a097cbd5874a8f"},
-    {file = "websockets-11.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:c2d6429c9bcd70ed8126a1f9ca6069e4ab95c96a3cc141fc84ce02917f7b45ec"},
-    {file = "websockets-11.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff3f67567862a853af2c0db362ede8249be50c576cd9eaf380736c6fce840414"},
-    {file = "websockets-11.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b86ce3d17bcc4b6556b2a2e1277beed74ff6b1de23f002f9763e9875e8ba361d"},
-    {file = "websockets-11.0-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59c4b458cc09ea6470a5eee98b06ccaa84f2a193b92e337a879612614df0f8eb"},
-    {file = "websockets-11.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:e5e21aeb350906dfcff321bfa6c60541a1d05cadb6d431ecf9d6376365be60d4"},
-    {file = "websockets-11.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:8731189f6985b239a6c34a353c36b45cb3c9fed1c287fbcf7f61df9e4a7ac392"},
-    {file = "websockets-11.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee3aa7660ae0d3a4e47517bb5a545b9a02ff7b9632a640f617e755990ef65f66"},
-    {file = "websockets-11.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:027aabfd053715ce0f5f6fc5107e5093e05b3c94fa555fb65375aa09cb845a66"},
-    {file = "websockets-11.0-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e8c729aa179ef105f096cad12070aef230be9e2ae509eb47c3cdd9257213c14"},
-    {file = "websockets-11.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:ff607c6e16409ac83f1ae59cc96167fead577bc652e8dff48f7458ce082372ff"},
-    {file = "websockets-11.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ca3d7c08f472c40f28bb9fb99610d28dc97137612ab5308f80dac7ce79f87fe1"},
-    {file = "websockets-11.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f179deef8288dd8ec227d644ba5b711609093b634008643561f6d9c74938c3c"},
-    {file = "websockets-11.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:269d33f1573a31130da9afd63a2558f60131522d3fe86d0aa2d1612ad065d27c"},
-    {file = "websockets-11.0-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb0b306c1180d0268341447982b415aca7c072c84b4a59688dbc1d7d2ec25df9"},
-    {file = "websockets-11.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:6ae209f11e433575e17d5d6e61a2f77ceda53b4bce07df55af614aa1d618e2e7"},
-    {file = "websockets-11.0-py3-none-any.whl", hash = "sha256:6ebd971b9b2c0aaa2188c472016e4dad93108b3db425a33ad584bdc41b22026d"},
-    {file = "websockets-11.0.tar.gz", hash = "sha256:19d638549c470f5fd3b67b52b2a08f2edba5a04e05323a706937e35f5f19d056"},
+    {file = "websockets-11.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d30cc1a90bcbf9e22e1f667c1c5a7428e2d37362288b4ebfd5118eb0b11afa9"},
+    {file = "websockets-11.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dc77283a7c7b2b24e00fe8c3c4f7cf36bba4f65125777e906aae4d58d06d0460"},
+    {file = "websockets-11.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0929c2ebdf00cedda77bf77685693e38c269011236e7c62182fee5848c29a4fa"},
+    {file = "websockets-11.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db234da3aff01e8483cf0015b75486c04d50dbf90004bd3e5b46d384e1bd6c9e"},
+    {file = "websockets-11.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7fdfbed727ce6b4b5e6622d15a6efb2098b2d9e22ba4dc54b2e3ce80f982045"},
+    {file = "websockets-11.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5f3d0d177b3db3d1d02cce7ba6c0063586499ac28afe0c992be74ffc40d9257"},
+    {file = "websockets-11.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:25ea5dbd3b00c56b034639dc6fe4d1dd095b8205bab1782d9a47cb020695fdf4"},
+    {file = "websockets-11.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:dbeada3b8f1f6d9497840f761906c4236f912a42da4515520168bc7c525b52b0"},
+    {file = "websockets-11.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:892959b627eedcdf98ac7022f9f71f050a59624b380b67862da10c32ea3c221a"},
+    {file = "websockets-11.0.1-cp310-cp310-win32.whl", hash = "sha256:fc0a96a6828bfa6f1ccec62b54630bcdcc205d483f5a8806c0a8abb26101c54b"},
+    {file = "websockets-11.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:3a88375b648a2c479532943cc19a018df1e5fcea85d5f31963c0b22794d1bdc1"},
+    {file = "websockets-11.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3cf18bbd44b36749b7b66f047a30a40b799b8c0bd9a1b9173cba86a234b4306b"},
+    {file = "websockets-11.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:deb0dd98ea4e76b833f0bfd7a6042b51115360d5dfcc7c1daa72dfc417b3327a"},
+    {file = "websockets-11.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:45a85dc6b3ff76239379feb4355aadebc18d6e587c8deb866d11060755f4d3ea"},
+    {file = "websockets-11.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d68bd2a3e9fff6f7043c0a711cb1ebba9f202c196a3943d0c885650cd0b6464"},
+    {file = "websockets-11.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfd0b9b18d64c51e5cd322e16b5bf4fe490db65c9f7b18fd5382c824062ead7e"},
+    {file = "websockets-11.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0e6253c36e42f2637cfa3ff9b3903df60d05ec040c718999f6a0644ce1c497"},
+    {file = "websockets-11.0.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:12180bc1d72c6a9247472c1dee9dfd7fc2e23786f25feee7204406972d8dab39"},
+    {file = "websockets-11.0.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:a797da96d4127e517a5cb0965cd03fd6ec21e02667c1258fa0579501537fbe5c"},
+    {file = "websockets-11.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:07cc20655fb16aeef1a8f03236ba8671c61d332580b996b6396a5b7967ba4b3d"},
+    {file = "websockets-11.0.1-cp311-cp311-win32.whl", hash = "sha256:a01c674e0efe0f14aec7e722ed0e0e272fa2f10e8ea8260837e1f4f5dc4b3e53"},
+    {file = "websockets-11.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:2796f097841619acf053245f266a4f66cb27c040f0d9097e5f21301aab95ff43"},
+    {file = "websockets-11.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:54d084756c50dfc8086dce97b945f210ca43950154e1e04a44a30c6e6a2bcbb1"},
+    {file = "websockets-11.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fe2aed5963ca267c40a2d29b1ee4e8ab008ac8d5daa284fdda9275201b8a334"},
+    {file = "websockets-11.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84e92dbac318a84fef722f38ca57acef19cbb89527aba5d420b96aa2656970ee"},
+    {file = "websockets-11.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec4e87eb9916b481216b1fede7d8913be799915f5216a0c801867cbed8eeb903"},
+    {file = "websockets-11.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d4e0990b6a04b07095c969969da659eecf9069cf8e7b8f49c8f5ee1bb50e3352"},
+    {file = "websockets-11.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c90343fd0774749d23c1891dd8b3e9210f9afd30986673ce0f9d5857f5cb1562"},
+    {file = "websockets-11.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ac042e8ba9d7f2618e84af27927fdce0f3e03528eb74f343977486c093868389"},
+    {file = "websockets-11.0.1-cp37-cp37m-win32.whl", hash = "sha256:385c5391becb9b58e0a4f33345e12762fd857ccf9fbf6fee428669929ba45e4c"},
+    {file = "websockets-11.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:aef1602db81096ce3d3847865128c8879635bdad7963fb2b7df290edb9e9150a"},
+    {file = "websockets-11.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:52ba83ea132390e426f9a7b48848248a2dc0e7120ca8c65d5a8fc1efaa4eb51b"},
+    {file = "websockets-11.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:007ed0d62f7e06eeb6e3a848b0d83b9fbd9e14674a59a61326845f27d20d7452"},
+    {file = "websockets-11.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f888b9565ca1d1c25ab827d184f57f4772ffbfa6baf5710b873b01936cc335ee"},
+    {file = "websockets-11.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db78535b791840a584c48cf3f4215eae38a7e2f43271ecd27ce4ba8a798beaaa"},
+    {file = "websockets-11.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fa1c23ed3a02732fba906ec337df65d4cc23f9f453635e1a803c285b59c7d987"},
+    {file = "websockets-11.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e039f106d48d3c241f1943bccfb383bd38ec39900d6dcaad0c73cc5fe129f346"},
+    {file = "websockets-11.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b0ed24a3aa4213029e100257e5e73c5f912e70ca35630081de94b7f9e2cf4a9b"},
+    {file = "websockets-11.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:d5a3022f9291bf2d35ebf65929297d625e68effd3a5647b8eb8b89d51b09394c"},
+    {file = "websockets-11.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:1cb23597819f68ac6a6d133a002a1b3ef12a22850236b083242c93f81f206d5a"},
+    {file = "websockets-11.0.1-cp38-cp38-win32.whl", hash = "sha256:349dd1fa56a30d530555988be98013688de67809f384671883f8bf8b8c9de984"},
+    {file = "websockets-11.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:87ae582cf2319e45bc457a57232daded27a3c771263cab42fb8864214bbd74ea"},
+    {file = "websockets-11.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a88815a0c6253ad1312ef186620832fb347706c177730efec34e3efe75e0e248"},
+    {file = "websockets-11.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d5a6fa353b5ef36970c3bd1cd7cecbc08bb8f2f1a3d008b0691208cf34ebf5b0"},
+    {file = "websockets-11.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5ffe6fc5e5fe9f2634cdc59b805e4ba1fcccf3a5622f5f36c3c7c287f606e283"},
+    {file = "websockets-11.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b138f4bf8a64c344e12c76283dac279d11adab89ac62ae4a32ac8490d3c94832"},
+    {file = "websockets-11.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aedd94422745da60672a901f53de1f50b16e85408b18672b9b210db4a776b5a6"},
+    {file = "websockets-11.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4667d4e41fa37fa3d836b2603b8b40d6887fa4838496d48791036394f7ace39"},
+    {file = "websockets-11.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:43e0de552be624e5c0323ff4fcc9f0b4a9a6dc6e0116b8aa2cbb6e0d3d2baf09"},
+    {file = "websockets-11.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:ceeef57b9aec8f27e523de4da73c518ece7721aefe7064f18aa28baabfe61b94"},
+    {file = "websockets-11.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9d91279d57f6546eaf43671d1de50621e0578f13c2f17c96c458a72d170698d7"},
+    {file = "websockets-11.0.1-cp39-cp39-win32.whl", hash = "sha256:29282631da3bfeb5db497e4d3d94d56ee36222fbebd0b51014e68a2e70736fb1"},
+    {file = "websockets-11.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:e2654e94c705ce9b768441d8e3a387a84951ca1056efdc4a26a4a6ee723c01b6"},
+    {file = "websockets-11.0.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:60a19d4ff5f451254f8623f6aa4169065f73a50ec7b59ab6b9dcddff4aa00267"},
+    {file = "websockets-11.0.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a58e83f82098d062ae5d4cbe7073b8783999c284d6f079f2fefe87cd8957ac8"},
+    {file = "websockets-11.0.1-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b91657b65355954e47f0df874917fa200426b3a7f4e68073326a8cfc2f6deef8"},
+    {file = "websockets-11.0.1-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53b8e1ee01eb5b8be5c8a69ae26b0820dbc198d092ad50b3451adc3cdd55d455"},
+    {file = "websockets-11.0.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:5d8d5d17371ed9eb9f0e3a8d326bdf8172700164c2e705bc7f1905a719a189be"},
+    {file = "websockets-11.0.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:e53419201c6c1439148feb99de6b307651a88b8defd41348cc23bbe2a290de1d"},
+    {file = "websockets-11.0.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:718d19c494637f28e651031b3df6a791b9e86e0097c65ed5e8ec49b400b1210e"},
+    {file = "websockets-11.0.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f7b2544eb3e7bc39ce59812371214cd97762080dab90c3afc857890039384753"},
+    {file = "websockets-11.0.1-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec4a887d2236e3878c07033ad5566f6b4d5d954b85f92a219519a1745d0c93e9"},
+    {file = "websockets-11.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:ae59a9f0a77ecb0cbdedea7d206a547ff136e8bfbc7d2d98772fb02d398797bb"},
+    {file = "websockets-11.0.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ef35cef161f76031f833146f895e7e302196e01c704c00d269c04d8e18f3ac37"},
+    {file = "websockets-11.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79b6548e57ab18f071b9bfe3ffe02af7184dd899bc674e2817d8fe7e9e7489ec"},
+    {file = "websockets-11.0.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a8d9793f3fb0da16232503df14411dabafed5a81fc9077dc430cfc6f60e71179"},
+    {file = "websockets-11.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42aa05e890fcf1faed8e535c088a1f0f27675827cbacf62d3024eb1e6d4c9e0c"},
+    {file = "websockets-11.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:5d4f4b341100d313b08149d7031eb6d12738ac758b0c90d2f9be8675f401b019"},
+    {file = "websockets-11.0.1-py3-none-any.whl", hash = "sha256:85b4127f7da332feb932eee833c70e5e1670469e8c9de7ef3874aa2a91a6fbb2"},
+    {file = "websockets-11.0.1.tar.gz", hash = "sha256:369410925b240b30ef1c1deadbd6331e9cd865ad0b8966bf31e276cc8e0da159"},
 ]
 
 [[package]]
@@ -1393,4 +1405,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "8e282ea2901dad71ad4eef606df68b00e7dd9ca412626894f98f9c5428f4383e"
+content-hash = "9e686b88deaa89938e86dd12286c4d71bde55e3670f37e423033e7f35c0085ec"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -27,6 +27,8 @@ fastapi = "^0.95.0"
 uvicorn = {extras = ["standard"], version = "^0.21.1"}
 
 nixpkgs-graph-core = { version = "^0.1.0" }
+websockets = "^11.0.1"
+backoff = "^2.2.1"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
As noted in #72, the default transport implemented by `gremlinpython` lacks a mechanism to reconnect in case of unexpected disconnects, network issues, etc. This PR introduces a custom transport implementation which is built directly on the `websockets` library and includes logic for re-establishing client connections in case of connection errors. 

In addition to the unit tests, I have also manually tested these changes locally and on the demo deployment.

Closes #72