### PR TITLE
Update output path schema

### DIFF
--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -59,8 +59,8 @@ def core_to_graph_model(pkg: model.Package) -> list[graph.Package]:
             core_pkg=pkg,
         )
     return [
-        graph.Package(pname=pkg.nixpkgs_metadata.pname, outputPath=op)
-        for op in pkg.output_paths.values()
+        graph.Package(pname=pkg.nixpkgs_metadata.pname, outputPath=op.path)
+        for op in pkg.output_paths
     ]
 
 

--- a/api/explorer/api/test/test_ingest.py
+++ b/api/explorer/api/test/test_ingest.py
@@ -12,7 +12,7 @@ from explorer.api import graph
 
 dummy_pkg_d = model.Package(
     name="D",
-    output_paths={model.OutputPathName.OUT: "/D"},
+    output_paths=[model.OutputPath(name=model.OutputPathName.OUT, path="/D")],
     nixpkgs_metadata=model.NixpkgsMetadata(
         pname="D", version="1.0", broken=False, license="MIT"
     ),
@@ -22,7 +22,7 @@ dummy_pkg_d = model.Package(
 
 dummy_pkg_c = model.Package(
     name="C",
-    output_paths={model.OutputPathName.OUT: "/C"},
+    output_paths=[model.OutputPath(name=model.OutputPathName.OUT, path="/C")],
     nixpkgs_metadata=model.NixpkgsMetadata(
         pname="C",
         version="1.0",
@@ -34,7 +34,7 @@ dummy_pkg_c = model.Package(
 
 dummy_pkg_b = model.Package(
     name="B",
-    output_paths={model.OutputPathName.OUT: "/B"},
+    output_paths=[model.OutputPath(name=model.OutputPathName.OUT, path="/B")],
     nixpkgs_metadata=model.NixpkgsMetadata(
         pname="B", version="1.0", broken=False, license="MIT"
     ),
@@ -48,7 +48,7 @@ dummy_pkg_b = model.Package(
 
 dummy_pkg_a = model.Package(
     name="A",
-    output_paths={model.OutputPathName.OUT: "/A"},
+    output_paths=[model.OutputPath(name=model.OutputPathName.OUT, path="/A")],
     nixpkgs_metadata=model.NixpkgsMetadata(
         pname="A", version="1.0", broken=False, license="MIT"
     ),
@@ -98,10 +98,10 @@ def test_unit_core_to_graph_model():
 
     pkg = model.Package(
         name="foo",
-        output_paths={
-            model.OutputPathName.DEV: "/foo/dev",
-            model.OutputPathName.LIB: "/foo/lib",
-        },
+        output_paths=[
+            model.OutputPath(name=model.OutputPathName.DEV, path="/foo/dev"),
+            model.OutputPath(name=model.OutputPathName.LIB, path="/foo/lib"),
+        ],
         nixpkgs_metadata=model.NixpkgsMetadata(
             pname="foo", version="1.0", broken=False, license="MIT"
         ),
@@ -121,7 +121,7 @@ def test_unit_core_to_graph_model_no_output_path():
 
     pkg = model.Package(
         name="foo",
-        output_paths={},
+        output_paths=[],
         nixpkgs_metadata=model.NixpkgsMetadata(
             pname="foo", version="1.0", broken=False, license="MIT"
         ),
@@ -136,7 +136,7 @@ def test_unit_core_to_graph_model_no_metadata_raises():
 
     pkg = model.Package(
         name="foo",
-        output_paths={},
+        output_paths=[],
         nixpkgs_metadata=None,
         build_inputs=[],
     )
@@ -150,7 +150,7 @@ def test_unit_core_to_graph_model_no_pname_raises():
 
     pkg = model.Package(
         name="foo",
-        output_paths={},
+        output_paths=[],
         nixpkgs_metadata=model.NixpkgsMetadata(
             pname=None, version="1.0", broken=False, license="MIT"
         ),
@@ -176,13 +176,18 @@ def test_unit_traverse_visits_all_nodes():
 
     traverse(dummy_nix_graph, visit_root_node, visit_layer)
 
-    assert set(visited_root_pkgs) == set(dummy_pkg_a.output_paths.values())
-    assert set(visited_pkgs) == (
-        set(dummy_pkg_a.output_paths.values())
-        | set(dummy_pkg_b.output_paths.values())
-        | set(dummy_pkg_c.output_paths.values())
-        | set(dummy_pkg_d.output_paths.values())
+    expected_root_pkgs = set(map(lambda x: x.path, dummy_pkg_a.output_paths))
+    expected_pkgs = set(
+        map(
+            lambda x: x.path,
+            dummy_pkg_a.output_paths
+            + dummy_pkg_b.output_paths
+            + dummy_pkg_c.output_paths
+            + dummy_pkg_d.output_paths,
+        )
     )
+    assert set(visited_root_pkgs) == expected_root_pkgs
+    assert set(visited_pkgs) == expected_pkgs
 
 
 def test_unit_ingest_nix_graph(graph_connection: DriverRemoteConnection):

--- a/api/explorer/api/test/test_ingest.py
+++ b/api/explorer/api/test/test_ingest.py
@@ -12,7 +12,7 @@ from explorer.api import graph
 
 dummy_pkg_d = model.Package(
     name="D",
-    output_paths=[model.OutputPath(name=model.OutputPathName.OUT, path="/D")],
+    output_paths=[model.OutputPath(name="out", path="/D")],
     nixpkgs_metadata=model.NixpkgsMetadata(
         pname="D", version="1.0", broken=False, license="MIT"
     ),
@@ -22,7 +22,7 @@ dummy_pkg_d = model.Package(
 
 dummy_pkg_c = model.Package(
     name="C",
-    output_paths=[model.OutputPath(name=model.OutputPathName.OUT, path="/C")],
+    output_paths=[model.OutputPath(name="out", path="/C")],
     nixpkgs_metadata=model.NixpkgsMetadata(
         pname="C",
         version="1.0",
@@ -34,7 +34,7 @@ dummy_pkg_c = model.Package(
 
 dummy_pkg_b = model.Package(
     name="B",
-    output_paths=[model.OutputPath(name=model.OutputPathName.OUT, path="/B")],
+    output_paths=[model.OutputPath(name="out", path="/B")],
     nixpkgs_metadata=model.NixpkgsMetadata(
         pname="B", version="1.0", broken=False, license="MIT"
     ),
@@ -48,7 +48,7 @@ dummy_pkg_b = model.Package(
 
 dummy_pkg_a = model.Package(
     name="A",
-    output_paths=[model.OutputPath(name=model.OutputPathName.OUT, path="/A")],
+    output_paths=[model.OutputPath(name="out", path="/A")],
     nixpkgs_metadata=model.NixpkgsMetadata(
         pname="A", version="1.0", broken=False, license="MIT"
     ),
@@ -99,8 +99,8 @@ def test_unit_core_to_graph_model():
     pkg = model.Package(
         name="foo",
         output_paths=[
-            model.OutputPath(name=model.OutputPathName.DEV, path="/foo/dev"),
-            model.OutputPath(name=model.OutputPathName.LIB, path="/foo/lib"),
+            model.OutputPath(name="dev", path="/foo/dev"),
+            model.OutputPath(name="lib", path="/foo/lib"),
         ],
         nixpkgs_metadata=model.NixpkgsMetadata(
             pname="foo", version="1.0", broken=False, license="MIT"
@@ -110,7 +110,7 @@ def test_unit_core_to_graph_model():
     converted_pkgs = core_to_graph_model(pkg)
 
     expected_pkg_dev = graph.Package(pname="foo", outputPath="/foo/dev")
-    expected_pkg_lib = graph.Package(pname="foo", outputPath="/foo/dev")
+    expected_pkg_lib = graph.Package(pname="foo", outputPath="/foo/lib")
     assert expected_pkg_dev in converted_pkgs
     assert expected_pkg_lib in converted_pkgs
 

--- a/core/explorer/core/model.py
+++ b/core/explorer/core/model.py
@@ -33,7 +33,7 @@ class BuildInput(BaseModel):
     """A build input to a Nix derivation"""
 
     build_input_type: BuildInputType = Field(description="The type of build input.")
-    package: "Package" = Field("The input package")
+    package: "Package" = Field(description="The input package")
 
     class Config:
         use_enum_values = True

--- a/core/explorer/core/model.py
+++ b/core/explorer/core/model.py
@@ -17,7 +17,7 @@ class NixpkgsMetadata(BaseModel):
 class OutputPath(BaseModel):
     """A Nix outputPath"""
 
-    name: str = Field(description="The output path's name (doc, dev, etc.)")
+    name: str = Field(description="The output path's name (out, doc, dev, ...)")
     path: str = Field(description="The output path")
 
 

--- a/core/explorer/core/model.py
+++ b/core/explorer/core/model.py
@@ -14,22 +14,10 @@ class NixpkgsMetadata(BaseModel):
     license: str = Field(description="The package's license")
 
 
-class OutputPathName(Enum):
-    """
-    The name of an outputPath.
-
-    In Nix, output paths can have different names which get included in the store path
-    """
-
-    OUT = "out"
-    LIB = "lib"
-    DEV = "dev"
-
-
 class OutputPath(BaseModel):
     """A Nix outputPath"""
 
-    name: OutputPathName = Field(description="The output path's name")
+    name: str = Field(description="The output path's name (doc, dev, etc.)")
     path: str = Field(description="The output path")
 
 

--- a/core/explorer/core/model.py
+++ b/core/explorer/core/model.py
@@ -26,6 +26,13 @@ class OutputPathName(Enum):
     DEV = "dev"
 
 
+class OutputPath(BaseModel):
+    """A Nix outputPath"""
+
+    name: OutputPathName = Field(description="The output path's name")
+    path: str = Field(description="The output path")
+
+
 class BuildInputType(Enum):
     """The type of build input. In Nix there are three different types."""
 
@@ -48,8 +55,8 @@ class Package(BaseModel):
     """A Nix package, which is an evaluated (not realized) derivation."""
 
     name: str = Field(description="The name of the package")
-    output_paths: dict[OutputPathName, str] = Field(
-        description="A mapping of output path names to corresponding store paths"
+    output_paths: list[OutputPath] = Field(
+        description="A list of the package's output paths"
     )
     nixpkgs_metadata: NixpkgsMetadata | None = Field(
         default=None, description="Optional metadata specific to packages from nixpkgs"

--- a/core/nixpkgs-graph.schema.json
+++ b/core/nixpkgs-graph.schema.json
@@ -14,27 +14,15 @@
     "packages"
   ],
   "definitions": {
-    "OutputPathName": {
-      "title": "OutputPathName",
-      "description": "The name of an outputPath.\n\nIn Nix, output paths can have different names which get included in the store path",
-      "enum": [
-        "out",
-        "lib",
-        "dev"
-      ]
-    },
     "OutputPath": {
       "title": "OutputPath",
       "description": "A Nix outputPath",
       "type": "object",
       "properties": {
         "name": {
-          "description": "The output path's name",
-          "allOf": [
-            {
-              "$ref": "#/definitions/OutputPathName"
-            }
-          ]
+          "title": "Name",
+          "description": "The output path's name (doc, dev, etc.)",
+          "type": "string"
         },
         "path": {
           "title": "Path",

--- a/core/nixpkgs-graph.schema.json
+++ b/core/nixpkgs-graph.schema.json
@@ -91,7 +91,7 @@
         },
         "package": {
           "title": "Package",
-          "default": "The input package",
+          "description": "The input package",
           "allOf": [
             {
               "$ref": "#/definitions/Package"
@@ -100,7 +100,8 @@
         }
       },
       "required": [
-        "build_input_type"
+        "build_input_type",
+        "package"
       ]
     },
     "Package": {

--- a/core/nixpkgs-graph.schema.json
+++ b/core/nixpkgs-graph.schema.json
@@ -14,6 +14,39 @@
     "packages"
   ],
   "definitions": {
+    "OutputPathName": {
+      "title": "OutputPathName",
+      "description": "The name of an outputPath.\n\nIn Nix, output paths can have different names which get included in the store path",
+      "enum": [
+        "out",
+        "lib",
+        "dev"
+      ]
+    },
+    "OutputPath": {
+      "title": "OutputPath",
+      "description": "A Nix outputPath",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The output path's name",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OutputPathName"
+            }
+          ]
+        },
+        "path": {
+          "title": "Path",
+          "description": "The output path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "path"
+      ]
+    },
     "NixpkgsMetadata": {
       "title": "NixpkgsMetadata",
       "description": "Package metadata defined by nixpkgs specifically.",
@@ -94,10 +127,10 @@
         },
         "output_paths": {
           "title": "Output Paths",
-          "description": "A mapping of output path names to corresponding store paths",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "description": "A list of the package's output paths",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OutputPath"
           }
         },
         "nixpkgs_metadata": {


### PR DESCRIPTION
Updated the schema of `Package.output_paths` to be an array of `OutputPath` objects rather than an untyped object of strings. This is necessary since pydantic's json schema generation for `dict[Enum, str]` produce json objects whose only requirement is that their values are strings.