### PR TITLE
Adapt ingestion process to new schema

### DIFF
--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -115,8 +115,9 @@ def _do_next_graph_level(
             packages = search_package_by_path(model_nix_graph, build_input.output_path)
             for p in packages:
                 try:
-                    # Since build_inputs is defined using the core model, we need to parse
-                    # it into the graph model similar to what we do above for model_pkg.
+                    # Since build_inputs is defined using the core model, we need to
+                    # parse it into the graph model similar to what we do above for
+                    # model_pkg.
                     build_input_pkgs = safe_parse_package(p)
                 except IngestionError as e:
                     logger.exception(e)

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -105,7 +105,7 @@ def split_nix_graph(
     nix_graph: model.NixGraph,
 ) -> tuple[list[graph.Package], list[tuple[graph.Package, graph.Edge, graph.Package]]]:
     """
-    Splits a Nix graph into API packages and edges.
+    Turn a parsed NixGraph from core model into two lists, a list of nodes (Package) and a list of edges, in the API model.
 
     Args:
         nix_graph (model.NixGraph): The Nix graph to split.

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -103,7 +103,7 @@ def _edge_from_build_input_type(build_input_type: model.BuildInputType) -> graph
 
 def split_nix_graph(
     nix_graph: model.NixGraph,
-) -> Tuple[list[graph.Package], list[Tuple[graph.Package, graph.Edge, graph.Package]]]:
+) -> tuple[list[graph.Package], list[tuple[graph.Package, graph.Edge, graph.Package]]]:
     """
     Splits a Nix graph into API packages and edges.
 

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -121,13 +121,22 @@ def split_nix_graph(
         Exception: If package metadata cannot be found for the output path corresponding
     to an edge's input vertex.
     """
+    # A dictionary that maps package output paths to package objects.
     packages = {}
+
+    # A dictionary that maps pairs of package output paths to edge objects.
     edge_refs = {}
+
+    # A list of tuples containing package, edge, and dependency package objects.
     edges = []
+
+    # Iterate over each package in the Nix graph
     for p in nix_graph.packages:
         parsed = safe_parse_package(p)
         for ps in parsed:
             packages[ps.outputPath] = ps
+            # Populate edge_refs dictionary with package output path pairs
+            # and their corresponding edge objects
             edge_refs |= {
                 (
                     ps.outputPath,
@@ -157,6 +166,7 @@ def split_nix_graph(
             f"Warning: {len(missing)} build input(s) in the input JSON file "
             "do not have a corresponding package and will be ignored."
         )
+    # Return the list of API package objects and the list of API package edges
     return list(packages.values()), edges
 
 

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -111,14 +111,14 @@ def split_nix_graph(
         nix_graph (model.NixGraph): parsed NixGraph (core model)
 
     Returns:
-        Tuple[
+        tuple[
             List[graph.Package],
-            List[Tuple[graph.Package, graph.Edge, graph.Package]]
+            List[tuple[graph.Package, graph.Edge, graph.Package]]
         ]:
         A tuple containing the list of nodes (packages) and the list of edges, both in the graph API model.
 
     Raises:
-        Exception: when the output path of an edge's vertex does not correspond to any derivation in the NixGraph 
+        Exception: when the output path of an edge's vertex does not correspond to any derivation in the NixGraph
     """
     # Map from output path to package node
     packages: dict[str, Package] = {}
@@ -193,7 +193,6 @@ def ingest_nix_graph(
         return thread_local.g
 
     def write_package(p: graph.Package):
-        # print(p)
         g = get_local_client()
         graph.insert_unique_vertex(p, g)
 

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -1,11 +1,9 @@
-import builtins
 import logging
 import threading
-from concurrent.futures import ALL_COMPLETED, ThreadPoolExecutor, wait
+from concurrent.futures import ThreadPoolExecutor, wait
 from contextlib import closing
 from typing import Callable, Tuple
 
-from concurrent.futures import ALL_COMPLETED, ThreadPoolExecutor, wait
 import click
 from explorer.core import model
 from gremlin_python.process.anonymous_traversal import traversal
@@ -100,26 +98,6 @@ def _edge_from_build_input_type(build_input_type: model.BuildInputType) -> graph
             "The provided BuildInputType does not correspond to a known edge type:"
             f" {build_input_type}"
         )
-
-
-def is_output_path_in_graph(nix_graph: model.NixGraph, search_path: str) -> bool:
-    """
-    Check if a given output path exists in a NixGraph.
-
-    Args:
-        nix_graph (model.NixGraph): A NixGraph object representing the graph to search.
-        search_path (str): The output path to search for.
-
-    Returns:
-        bool: True if the output path is present in the graph, False otherwise.
-
-    """
-    for package in nix_graph.packages:
-        if builtins.any(
-            output_path.path == search_path for output_path in package.output_paths
-        ):
-            return True
-    return False
 
 
 def split_nix_graph(nix_graph: model.NixGraph):

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -115,7 +115,7 @@ def split_nix_graph(
             List[graph.Package],
             List[Tuple[graph.Package, graph.Edge, graph.Package]]
         ]:
-        A tuple containing the list of API packages and the list of API package edges.
+        A tuple containing the list of nodes (packages) and the list of edges, both in the graph API model.
 
     Raises:
         Exception: If package metadata cannot be found for the output path corresponding

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -118,8 +118,7 @@ def split_nix_graph(
         A tuple containing the list of nodes (packages) and the list of edges, both in the graph API model.
 
     Raises:
-        Exception: If package metadata cannot be found for the output path corresponding
-    to an edge's input vertex.
+        Exception: when the output path of an edge's vertex does not correspond to any derivation in the NixGraph 
     """
     # A dictionary that maps package output paths to package objects.
     packages = {}

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -120,8 +120,8 @@ def split_nix_graph(
     Raises:
         Exception: when the output path of an edge's vertex does not correspond to any derivation in the NixGraph 
     """
-    # A dictionary that maps package output paths to package objects.
-    packages = {}
+    # Map from output path to package node
+    packages: dict[str, Package] = {}
 
     # A dictionary that maps pairs of package output paths to edge objects.
     edge_refs = {}

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -221,7 +221,10 @@ def main(graph_json: str, gremlin_server: str, gremlin_source: str):
     with closing(
         default_remote_connection(gremlin_server, traversal_source=gremlin_source)
     ) as remote:
-        g_factory = lambda: traversal().with_remote(remote)
+
+        def g_factory():
+            return traversal().with_remote(remote)
+
         click.echo("Done.")
 
         click.echo("Purging existing entities.")

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -108,7 +108,7 @@ def split_nix_graph(
     Turn a parsed NixGraph from core model into two lists, a list of nodes (Package) and a list of edges, in the API model.
 
     Args:
-        nix_graph (model.NixGraph): The Nix graph to split.
+        nix_graph (model.NixGraph): parsed NixGraph (core model)
 
     Returns:
         Tuple[

--- a/api/explorer/api/test/test_ingest.py
+++ b/api/explorer/api/test/test_ingest.py
@@ -163,7 +163,9 @@ def test_unit_ingest_nix_graph(graph_connection: DriverRemoteConnection):
     """Check that all expected nodes and edges are created when ingesting a nix graph"""
     from explorer.api.ingest import ingest_nix_graph
 
-    g_factory = lambda: traversal().with_remote(graph_connection)
+    def g_factory():
+        return traversal().with_remote(graph_connection)
+
     ingest_nix_graph(dummy_nix_graph, g_factory)
 
     n_nodes = g_factory().V().count().to_list()

--- a/api/explorer/api/test/test_ingest.py
+++ b/api/explorer/api/test/test_ingest.py
@@ -163,11 +163,11 @@ def test_unit_ingest_nix_graph(graph_connection: DriverRemoteConnection):
     """Check that all expected nodes and edges are created when ingesting a nix graph"""
     from explorer.api.ingest import ingest_nix_graph
 
-    g = traversal().with_remote(graph_connection)
-    ingest_nix_graph(dummy_nix_graph, g)
+    g_factory = lambda: traversal().with_remote(graph_connection)
+    ingest_nix_graph(dummy_nix_graph, g_factory)
 
-    n_nodes = g.V().count().to_list()
-    n_edges = g.E().count().to_list()
+    n_nodes = g_factory().V().count().to_list()
+    n_edges = g_factory().E().count().to_list()
 
     # TODO: It might be worth further tightening the assertions here in the future
     # since checking the count is only a rough approximation of correctness.

--- a/api/explorer/api/test/test_ingest.py
+++ b/api/explorer/api/test/test_ingest.py
@@ -41,7 +41,7 @@ dummy_pkg_b = model.Package(
     build_inputs=[
         model.BuildInput(
             build_input_type=model.BuildInputType.BUILD_INPUT,
-            output_path="/C",
+            output_path=dummy_pkg_c.output_paths[0].path,
         )
     ],
 )
@@ -55,11 +55,11 @@ dummy_pkg_a = model.Package(
     build_inputs=[
         model.BuildInput(
             build_input_type=model.BuildInputType.BUILD_INPUT,
-            output_path="/B",
+            output_path=dummy_pkg_b.output_paths[0].path,
         ),
         model.BuildInput(
             build_input_type=model.BuildInputType.BUILD_INPUT,
-            output_path="/D",
+            output_path=dummy_pkg_d.output_paths[0].path,
         ),
     ],
 )

--- a/api/explorer/api/test/test_ingest.py
+++ b/api/explorer/api/test/test_ingest.py
@@ -159,36 +159,6 @@ def test_unit_core_to_graph_model_no_pname_raises():
         core_to_graph_model(pkg)
 
 
-def test_unit_traverse_visits_all_nodes():
-    """Check traverse visits all nodes in the input graph"""
-    from explorer.api.ingest import traverse
-
-    visited_root_pkgs: list[str] = []
-    visited_pkgs: list[str] = []
-
-    def visit_root_node(p: graph.Package):
-        visited_root_pkgs.append(p.outputPath)
-
-    def visit_layer(p: graph.Package, up: graph.Package, _e: graph.Edge):
-        visited_pkgs.append(p.outputPath)
-        visited_pkgs.append(up.outputPath)
-
-    traverse(dummy_nix_graph, visit_root_node, visit_layer)
-
-    expected_root_pkgs = set(map(lambda x: x.path, dummy_pkg_a.output_paths))
-    expected_pkgs = set(
-        map(
-            lambda x: x.path,
-            dummy_pkg_a.output_paths
-            + dummy_pkg_b.output_paths
-            + dummy_pkg_c.output_paths
-            + dummy_pkg_d.output_paths,
-        )
-    )
-    assert set(visited_root_pkgs) == expected_root_pkgs
-    assert set(visited_pkgs) == expected_pkgs
-
-
 def test_unit_ingest_nix_graph(graph_connection: DriverRemoteConnection):
     """Check that all expected nodes and edges are created when ingesting a nix graph"""
     from explorer.api.ingest import ingest_nix_graph

--- a/api/explorer/api/test/test_ingest.py
+++ b/api/explorer/api/test/test_ingest.py
@@ -41,7 +41,7 @@ dummy_pkg_b = model.Package(
     build_inputs=[
         model.BuildInput(
             build_input_type=model.BuildInputType.BUILD_INPUT,
-            package=dummy_pkg_c,
+            output_path="/C",
         )
     ],
 )
@@ -55,16 +55,18 @@ dummy_pkg_a = model.Package(
     build_inputs=[
         model.BuildInput(
             build_input_type=model.BuildInputType.BUILD_INPUT,
-            package=dummy_pkg_b,
+            output_path="/B",
         ),
         model.BuildInput(
             build_input_type=model.BuildInputType.BUILD_INPUT,
-            package=dummy_pkg_d,
+            output_path="/D",
         ),
     ],
 )
 
-dummy_nix_graph = model.NixGraph(packages=[dummy_pkg_a])
+dummy_nix_graph = model.NixGraph(
+    packages=[dummy_pkg_a, dummy_pkg_b, dummy_pkg_c, dummy_pkg_d]
+)
 
 
 #######################################################################################


### PR DESCRIPTION
This PR adapts ingestion process to new schema by mapping the buildInputs path to the corresponding package.

Should fix #81 