### PR TITLE
Modify pname and version in nixpkgs_metadata to fix pname conflicts

### DIFF
--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -41,26 +41,26 @@ def core_to_graph_model(pkg: model.Package) -> list[graph.Package]:
     Returns:
         list[graph.Package]
     """
-    if pkg.nixpkgs_metadata is None:
+    if pkg.parsed_name is None:
         raise IngestionError(
             (
-                "The provided package did not have its nixpkgs_metadata attribute set,"
+                "The provided package did not have its parsed_name attribute set,"
                 " but this is required for converting it to the schema used by the"
                 f" nixpkgs-graph-explorer graph. Package: {pkg}"
             ),
             core_pkg=pkg,
         )
-    if pkg.nixpkgs_metadata.pname is None:
+    if pkg.parsed_name.name is None:
         raise IngestionError(
             (
-                "The provided package did not have its nixpkgs_metadata.pname attribute"
+                "The provided package did not have its parsed_name.name attribute"
                 " set, but this is required for converting it to the schema used by the"
                 f" nixpkgs-graph-explorer graph. Package: {pkg}"
             ),
             core_pkg=pkg,
         )
     return [
-        graph.Package(pname=pkg.nixpkgs_metadata.pname, outputPath=op.path)
+        graph.Package(pname=pkg.parsed_name.name, outputPath=op.path)
         for op in pkg.output_paths
     ]
 

--- a/api/explorer/api/test/test_ingest.py
+++ b/api/explorer/api/test/test_ingest.py
@@ -101,6 +101,7 @@ def test_unit_core_to_graph_model():
 
     pkg = model.Package(
         name="foo",
+        parsed_name=model.ParsedName(name="foo", version="1.0")
         output_paths=[
             model.OutputPath(name="dev", path="/foo/dev"),
             model.OutputPath(name="lib", path="/foo/lib"),
@@ -125,6 +126,7 @@ def test_unit_core_to_graph_model_no_output_path():
     pkg = model.Package(
         name="foo",
         output_paths=[],
+        parsed_name=model.ParsedName(name="foo", version="1.0")
         nixpkgs_metadata=model.NixpkgsMetadata(
             pname="foo", version="1.0", broken=False, license="MIT"
         ),
@@ -133,13 +135,14 @@ def test_unit_core_to_graph_model_no_output_path():
     assert core_to_graph_model(pkg) == []
 
 
-def test_unit_core_to_graph_model_no_metadata_raises():
+def test_unit_core_to_graph_model_no_parsed_name_raises():
     """Check that attempting to parse a package without nixpkgs_metadata fails"""
     from explorer.api.ingest import IngestionError, core_to_graph_model
 
     pkg = model.Package(
         name="foo",
         output_paths=[],
+        parsed_name=None,
         nixpkgs_metadata=None,
         build_inputs=[],
     )
@@ -154,6 +157,7 @@ def test_unit_core_to_graph_model_no_pname_raises():
     pkg = model.Package(
         name="foo",
         output_paths=[],
+        parsed_name=model.ParsedName(name=None, version="1.0")
         nixpkgs_metadata=model.NixpkgsMetadata(
             pname=None, version="1.0", broken=False, license="MIT"
         ),

--- a/api/explorer/api/test/test_ingest.py
+++ b/api/explorer/api/test/test_ingest.py
@@ -13,6 +13,7 @@ from explorer.api.gremlin import default_remote_connection
 dummy_pkg_d = model.Package(
     name="D",
     output_paths=[model.OutputPath(name="out", path="/D")],
+    parsed_name=model.ParsedName(name="D", version="1.0"),
     nixpkgs_metadata=model.NixpkgsMetadata(
         pname="D", version="1.0", broken=False, license="MIT"
     ),
@@ -23,6 +24,7 @@ dummy_pkg_d = model.Package(
 dummy_pkg_c = model.Package(
     name="C",
     output_paths=[model.OutputPath(name="out", path="/C")],
+    parsed_name=model.ParsedName(name="C", version="1.0"),
     nixpkgs_metadata=model.NixpkgsMetadata(
         pname="C",
         version="1.0",
@@ -35,6 +37,7 @@ dummy_pkg_c = model.Package(
 dummy_pkg_b = model.Package(
     name="B",
     output_paths=[model.OutputPath(name="out", path="/B")],
+    parsed_name=model.ParsedName(name="B", version="1.0"),
     nixpkgs_metadata=model.NixpkgsMetadata(
         pname="B", version="1.0", broken=False, license="MIT"
     ),
@@ -49,6 +52,7 @@ dummy_pkg_b = model.Package(
 dummy_pkg_a = model.Package(
     name="A",
     output_paths=[model.OutputPath(name="out", path="/A")],
+    parsed_name=model.ParsedName(name="A", version="1.0"),
     nixpkgs_metadata=model.NixpkgsMetadata(
         pname="A", version="1.0", broken=False, license="MIT"
     ),

--- a/api/explorer/api/test/test_ingest.py
+++ b/api/explorer/api/test/test_ingest.py
@@ -101,7 +101,7 @@ def test_unit_core_to_graph_model():
 
     pkg = model.Package(
         name="foo",
-        parsed_name=model.ParsedName(name="foo", version="1.0")
+        parsed_name=model.ParsedName(name="foo", version="1.0"),
         output_paths=[
             model.OutputPath(name="dev", path="/foo/dev"),
             model.OutputPath(name="lib", path="/foo/lib"),
@@ -126,7 +126,7 @@ def test_unit_core_to_graph_model_no_output_path():
     pkg = model.Package(
         name="foo",
         output_paths=[],
-        parsed_name=model.ParsedName(name="foo", version="1.0")
+        parsed_name=model.ParsedName(name="foo", version="1.0"),
         nixpkgs_metadata=model.NixpkgsMetadata(
             pname="foo", version="1.0", broken=False, license="MIT"
         ),
@@ -157,7 +157,7 @@ def test_unit_core_to_graph_model_no_pname_raises():
     pkg = model.Package(
         name="foo",
         output_paths=[],
-        parsed_name=model.ParsedName(name=None, version="1.0")
+        parsed_name=model.ParsedName(name=None, version="1.0"),
         nixpkgs_metadata=model.NixpkgsMetadata(
             pname=None, version="1.0", broken=False, license="MIT"
         ),

--- a/core/explorer/core/model.py
+++ b/core/explorer/core/model.py
@@ -24,7 +24,9 @@ class OutputPath(BaseModel):
 class ParsedName(BaseModel):
     """The parsed output of the builtins.parseDrvName function."""
 
-    name: str = Field(description="The package name of the Nix derivation")
+    name: str | None = Field(
+        default=None, description="The package name of the Nix derivation"
+    )
     version: str = Field(description="The version of the Nix derivation")
 
 

--- a/core/explorer/core/model.py
+++ b/core/explorer/core/model.py
@@ -21,6 +21,13 @@ class OutputPath(BaseModel):
     path: str = Field(description="The output path")
 
 
+class ParsedName(BaseModel):
+    """The parsed output of the builtins.parseDrvName function."""
+
+    name: str = Field(description="The package name of the Nix derivation")
+    version: str = Field(description="The version of the Nix derivation")
+
+
 class BuildInputType(Enum):
     """The type of build input. In Nix there are three different types."""
 
@@ -45,6 +52,9 @@ class Package(BaseModel):
     name: str = Field(description="The name of the package")
     output_paths: list[OutputPath] = Field(
         description="A list of the package's output paths"
+    )
+    parsed_name: ParsedName | None = Field(
+        default=None, description="The parsed package name and version of the package"
     )
     nixpkgs_metadata: NixpkgsMetadata | None = Field(
         default=None, description="Optional metadata specific to packages from nixpkgs"

--- a/core/explorer/extract/nixpkgs-graph.nix
+++ b/core/explorer/extract/nixpkgs-graph.nix
@@ -50,7 +50,7 @@ let
       if !(nixpkgs.lib.isString name) then null else
       {
         inherit name;
-        parsedName = (builtins.parseDrvName name);
+        parsed_name = (builtins.parseDrvName name);
         nixpkgs_metadata =
           {
             pname = (builtins.tryEval (if okValue ? pname
@@ -90,7 +90,7 @@ in
   packages =
     map
       (drv: {
-        inherit (drv) name parsedName attributesPath derivationPath outputPath output_paths nixpkgs_metadata;
+        inherit (drv) name parsed_name attributesPath derivationPath outputPath output_paths nixpkgs_metadata;
         build_inputs = builtins.concatLists
           [
             (nixpkgs.lib.remove null

--- a/core/nixpkgs-graph.schema.json
+++ b/core/nixpkgs-graph.schema.json
@@ -21,7 +21,7 @@
       "properties": {
         "name": {
           "title": "Name",
-          "description": "The output path's name (doc, dev, etc.)",
+          "description": "The output path's name (out, doc, dev, ...)",
           "type": "string"
         },
         "path": {
@@ -33,6 +33,27 @@
       "required": [
         "name",
         "path"
+      ]
+    },
+    "ParsedName": {
+      "title": "ParsedName",
+      "description": "The parsed output of the builtins.parseDrvName function.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The package name of the Nix derivation",
+          "type": "string"
+        },
+        "version": {
+          "title": "Version",
+          "description": "The version of the Nix derivation",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
       ]
     },
     "NixpkgsMetadata": {
@@ -82,26 +103,22 @@
       "type": "object",
       "properties": {
         "build_input_type": {
-          "description": "The type of build input.",
+          "description": "The type of build input",
           "allOf": [
             {
               "$ref": "#/definitions/BuildInputType"
             }
           ]
         },
-        "package": {
-          "title": "Package",
-          "description": "The input package",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Package"
-            }
-          ]
+        "output_path": {
+          "title": "Output Path",
+          "description": "The output path of the input derivation",
+          "type": "string"
         }
       },
       "required": [
         "build_input_type",
-        "package"
+        "output_path"
       ]
     },
     "Package": {
@@ -121,6 +138,15 @@
           "items": {
             "$ref": "#/definitions/OutputPath"
           }
+        },
+        "parsed_name": {
+          "title": "Parsed Name",
+          "description": "The parsed package name and version of the package",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ParsedName"
+            }
+          ]
         },
         "nixpkgs_metadata": {
           "title": "Nixpkgs Metadata",


### PR DESCRIPTION
Within this PR, we have made modifications to the `pname` and `version` attributes in `nixpkgs_metadata` by utilizing the `parseDrvName` function. 

This adjustment enables us to obtain accurate values for `pname` and `version`. The updated `pname` will help resolve conflicts in the UI, while retaining the original `pname` and `version` outside of `nixpkgs_metadata` for future reference.

fix #84 