### PR TITLE
Update default Gremlin query

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -71,6 +71,6 @@ export async function rawQuery(query: string) {
 
 export async function getGraph(pkgName: string) {
   return await rawQuery(
-    `g.V().has('package','pname','${pkgName}').repeat(outE().otherV().simplePath()).until(outE().count().is(0).or().loops().is(gte(2))).path().by('pname').by('label').limit(20)`
+    `g.V().has('package','pname','${pkgName}').repeat(outE().otherV().simplePath()).until(outE().count().is(0).or().loops().is(gte(2))).path().by('pname').by('label')`
   );
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -71,6 +71,6 @@ export async function rawQuery(query: string) {
 
 export async function getGraph(pkgName: string) {
   return await rawQuery(
-    `g.V().filter{it.get().value('pname').matches('${pkgName}')}.repeat(outE().otherV().simplePath()).times(2).path().by('pname').by(label)`
+    `g.V().has('package','pname','${pkgName}').repeat(outE().otherV().simplePath()).until(outE().count().is(0).or().loops().is(gte(2))).path().by('pname').by('label').limit(20)`
   );
 }

--- a/web/src/code-editor.ts
+++ b/web/src/code-editor.ts
@@ -63,7 +63,9 @@ export class CodeEditor extends LitElement {
  .path()
  .by('pname')
  .by('label')
- .limit(20) `,
+ .limit(20)
+  // This limits the number of "paths" returned
+  // (where a path = [vertex, edge, vertex])`,
 
       extensions: [
         history(),

--- a/web/src/code-editor.ts
+++ b/web/src/code-editor.ts
@@ -39,19 +39,31 @@ export class CodeEditor extends LitElement {
   async addEditor() {
     const editor = await this._editor;
     let startState = EditorState.create({
-      doc: `g.V().filter{
-  it.get()
-    .value('pname')
-    // Edit the package name
-    .matches('nickel')
-}.repeat(
+      doc: `g.V()
+ .has(
+   'package',
+    'pname',
+    'python3'
+    // Package name goes here
+ )
+ .repeat(
    outE()
   .otherV()
   .simplePath())
-.times(2)
-.path()
-.by('pname')
-.by(label)`,
+ .until(
+   outE()
+  .count()
+  .is(0)
+  .or()
+  .loops()
+  .is(gte(2))
+  // The value in gte() limits
+  // the depth of the traversal
+ )
+ .path()
+ .by('pname')
+ .by('label')
+ .limit(20) `,
 
       extensions: [
         history(),


### PR DESCRIPTION
This PR updates the default Gremlin query by:
```
g.V()
    .has(
    'package',
    'pname',
    'python3'  // Package name goes here
    )
.repeat(outE().otherV().simplePath())
.until(
    outE().count().is(0).or().loops().is(gte(2)) // The value in gte() limits the depth of the traversal
)
.path()
.by('pname')
.by('label')
.limit(20) // This limits the number of "paths" returned (where a path = [vertex, edge, vertex])
``` 
In this way, the query will return data no matter how many layers of dependencies the package has.
 
Fixed #78 