### PR TITLE
CI: add nightly pipeline, that runs extraction

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,32 @@
+---
+name: Nightly
+
+on:
+  workflow_dispatch:  # This makes possible to launch the pipeline manually on the GitHub UI
+  schedule:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+    # Syntax: minute, hour, day of month, month, day of week
+    - cron: '0 4 * * 1-5'  # At 4AM on work days, see https://crontab.guru/
+
+jobs:
+  nightly:
+    name: Nightly
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v19
+
+      - name: Install dependencies
+        run: |
+          nix develop --command bash -c 'cd core && poetry install'
+
+      - name: Run extraction
+        run: |
+          # We write the output to a file, not to standard output,
+          # to keep log size small.
+          nix develop --command bash -c 'cd core && poetry run python -m explorer.extract graph.json'
+          wc -l graph.json


### PR DESCRIPTION
Fixes #34 

## What this PR does

This PR adds a nightly pipeline, that runs every day, and runs the extraction; to make sure it works.

## How to trust this PR

I tried running locally with [act](https://github.com/nektos/act) (with `act workflow_dispatch -j nightly`), but it fails without meaningful feedback. And we can't run the action manually until this PR is merged. I propose to simply merge the PR and then run the pipeline manually (it's possible since it has the `workflow_dispatch` keyword) and take it from there.

## Possible follow-up

Notify on Slack's [#nixkpkgs-graph-explorer](https://tweag.slack.com/archives/C0460A9J6P5) when the nightly fails, for example using [this action](https://www.ravsam.in/blog/send-slack-notification-when-github-actions-fails/). This can be done later.