### PR TITLE
Add retry logic to data ingestion

### DIFF
--- a/api/explorer/api/graph.py
+++ b/api/explorer/api/graph.py
@@ -89,6 +89,10 @@ class Package(UniqueGraphElement):
     pname: str
     outputPath: str
 
+    def __hash__(self):
+        # Calculate the hash based on the object's properties
+        return hash((self.pname, self.outputPath))
+
     @classmethod
     def label(cls) -> str:
         return "package"
@@ -114,6 +118,10 @@ class HasBuildInput(Edge):
     def label(cls) -> str:
         return "hasBuildInput"
 
+    def __hash__(self):
+        # Return a unique hash based on the object's properties
+        return hash(tuple(sorted(self.__dict__.items())))
+
 
 class HasPropagatedBuildInput(Edge):
     """
@@ -125,6 +133,10 @@ class HasPropagatedBuildInput(Edge):
     def label(cls) -> str:
         return "hasPropagatedBuildInput"
 
+    def __hash__(self):
+        # Return a unique hash based on the object's properties
+        return hash(tuple(sorted(self.__dict__.items())))
+
 
 class HasNativeBuiltInput(Edge):
     """A directed edge indicating a Nix nativeBuildInput dependency between packages"""
@@ -132,6 +144,10 @@ class HasNativeBuiltInput(Edge):
     @classmethod
     def label(cls) -> str:
         return "hasNativeBuildInput"
+
+    def __hash__(self):
+        # Return a unique hash based on the object's properties
+        return hash(tuple(sorted(self.__dict__.items())))
 
 
 def insert_unique_directed_edge(

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -3,7 +3,7 @@ import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor, wait
 from contextlib import closing
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional
 
 import backoff
 import click
@@ -213,7 +213,7 @@ def ingest_nix_package(
         graph.insert_unique_vertex(p, g)
 
     @backoff.on_exception(backoff.expo, Exception, max_tries=3)
-    def write_edge(input: Tuple[graph.Package, graph.Edge, graph.Package]):
+    def write_edge(input: tuple[graph.Package, graph.Edge, graph.Package]):
         current_package, edge, dependency_package = input
         g = get_local_client()
         graph.insert_unique_directed_edge(

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -197,8 +197,6 @@ def ingest_nix_package(
 
     packages, edges = split_nix_package(nix_package, ctxt)
 
-    retries = 3  # Number of retry attempts
-
     # Write nodes to the Gremlin graph
     click.echo("Writing nodes to the Gremlin graph...")
 

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -197,9 +197,6 @@ def ingest_nix_package(
 
     packages, edges = split_nix_package(nix_package, ctxt)
 
-    # Write nodes to the Gremlin graph
-    click.echo("Writing nodes to the Gremlin graph...")
-
     def get_local_client() -> GraphTraversalSource:
         thread_local = threading.local()
         g = getattr(thread_local, "g", None)
@@ -224,7 +221,8 @@ def ingest_nix_package(
         )
 
     with ThreadPoolExecutor() as ex:
-        click.echo("Writing packages")
+        # Write nodes to the Gremlin graph
+        click.echo("Writing nodes to the Gremlin graph...")
         with click.progressbar(length=len(packages)) as bar:
             futures = [ex.submit(write_package, p) for p in packages]
             for f in futures:
@@ -236,13 +234,14 @@ def ingest_nix_package(
             ]
             failed_packages_copy = failed_packages.copy()
             if failed_packages_copy:
-                click.echo("\nRetrying to write packages...")
+                click.echo("\nRetrying to write nodes...")
                 for i in range(len(failed_packages_copy)):
                     write_package(failed_packages_copy[i])
                     failed_packages.remove(failed_packages_copy[i])
                 click.echo("Done.")
 
-        click.echo("Writing edges")
+        # Write edges to the Gremlin graph
+        click.echo("Writing edges to the Gremlin graph...")
         with click.progressbar(length=len(edges)) as bar:
             futures = [ex.submit(write_edge, e) for e in edges]
             for f in futures:
@@ -254,8 +253,8 @@ def ingest_nix_package(
             if failed_edges_copy:
                 click.echo("\nRetrying to write edges...")
                 for i in range(len(failed_edges_copy)):
-                    write_edge(failed_packages_copy[i])
-                    failed_edges.remove(failed_packages_copy[i])
+                    write_edge(failed_edges_copy[i])
+                    failed_edges.remove(failed_edges_copy[i])
                 click.echo("Done.")
 
         # Check if all tasks executed successfully

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -247,9 +247,8 @@ def ingest_nix_package(
                         )
                     else:
                         # Mark the vertex as successfully ingested
-                        failed_packages[i] = None
-            failed_packages = [p for p in failed_packages if p is not None]
-            if not failed_packages:
+                        failed_packages.remove(failed_packages[i])
+            if failed_packages == []:
                 # All vertices ingested successfully, break the loop
                 break
             if attempt < retries:
@@ -281,9 +280,8 @@ def ingest_nix_package(
                         )
                     else:
                         # Mark the edge as successfully ingested
-                        failed_edges[i] = None
-            failed_edges = [e for e in failed_edges if e is not None]
-            if not failed_edges:
+                        failed_edges.remove(failed_edges[i])
+            if failed_edges == []:
                 # All edges ingested successfully, break the loop
                 break
 

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -236,8 +236,11 @@ def ingest_nix_package(
             if failed_packages_copy:
                 click.echo("\nRetrying to write nodes...")
                 for i in range(len(failed_packages_copy)):
-                    graph.insert_unique_vertex(failed_packages_copy[i], g_factory())
-                    failed_packages.remove(failed_packages_copy[i])
+                    try:
+                        graph.insert_unique_vertex(failed_packages_copy[i], g_factory())
+                        failed_packages.remove(failed_packages_copy[i])
+                    except Exception as e:
+                        logger.exception(f"An exception occurred: {e}")
                 click.echo("Done.")
 
         # Write edges to the Gremlin graph
@@ -253,13 +256,16 @@ def ingest_nix_package(
             if failed_edges_copy:
                 click.echo("\nRetrying to write edges...")
                 for i in range(len(failed_edges_copy)):
-                    graph.insert_unique_directed_edge(
-                        failed_edges_copy[i][1],
-                        from_vertex=failed_edges_copy[i][0],
-                        to_vertex=failed_edges_copy[i][2],
-                        g=g_factory(),
-                    )
-                    failed_edges.remove(failed_edges_copy[i])
+                    try:
+                        graph.insert_unique_directed_edge(
+                            failed_edges_copy[i][1],
+                            from_vertex=failed_edges_copy[i][0],
+                            to_vertex=failed_edges_copy[i][2],
+                            g=g_factory(),
+                        )
+                        failed_edges.remove(failed_edges_copy[i])
+                    except Exception as e:
+                        logger.exception(f"An exception occurred: {e}")
                 click.echo("Done.")
 
         # Check if all tasks executed successfully

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -236,6 +236,7 @@ def ingest_nix_package(
                 for f in futures:
                     f.add_done_callback(lambda _x: bar.update(1))
                 wait(futures)
+                failed_packages_copy = failed_packages.copy()
                 for i, f in enumerate(futures):
                     if f.exception():
                         logger.exception(
@@ -246,8 +247,8 @@ def ingest_nix_package(
                             str(f.exception()),
                         )
                     else:
-                        # Mark the vertex as successfully ingested
-                        failed_packages.remove(failed_packages[i])
+                        # Remove the vertex as successfully ingested
+                        failed_packages.remove(failed_packages_copy[i])
             if failed_packages == []:
                 # All vertices ingested successfully, break the loop
                 break
@@ -269,6 +270,7 @@ def ingest_nix_package(
                 for f in futures:
                     f.add_done_callback(lambda _x: bar.update(1))
                 wait(futures)
+                failed_edges_copy = failed_edges.copy()
                 for i, f in enumerate(futures):
                     if f.exception():
                         logger.exception(
@@ -279,8 +281,8 @@ def ingest_nix_package(
                             str(f.exception()),
                         )
                     else:
-                        # Mark the edge as successfully ingested
-                        failed_edges.remove(failed_edges[i])
+                        # Remove the edge as successfully ingested
+                        failed_edges.remove(failed_edges_copy[i])
             if failed_edges == []:
                 # All edges ingested successfully, break the loop
                 break

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -236,7 +236,7 @@ def ingest_nix_package(
             if failed_packages_copy:
                 click.echo("\nRetrying to write nodes...")
                 for i in range(len(failed_packages_copy)):
-                    write_package(failed_packages_copy[i])
+                    graph.insert_unique_vertex(failed_packages_copy[i], g_factory())
                     failed_packages.remove(failed_packages_copy[i])
                 click.echo("Done.")
 
@@ -253,7 +253,12 @@ def ingest_nix_package(
             if failed_edges_copy:
                 click.echo("\nRetrying to write edges...")
                 for i in range(len(failed_edges_copy)):
-                    write_edge(failed_edges_copy[i])
+                    graph.insert_unique_directed_edge(
+                        failed_edges_copy[i][1],
+                        from_vertex=failed_edges_copy[i][0],
+                        to_vertex=failed_edges_copy[i][2],
+                        g=g_factory(),
+                    )
                     failed_edges.remove(failed_edges_copy[i])
                 click.echo("Done.")
 

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -238,7 +238,7 @@ def ingest_nix_package(
                 wait(futures)
                 for i, f in enumerate(futures):
                     if f.exception():
-                        logger.error(
+                        logger.exception(
                             "Error occurred during package ingestion"
                             " (Attempt %s, Vertex: %s): %s",
                             attempt,
@@ -255,7 +255,7 @@ def ingest_nix_package(
                 click.echo("Retrying failed package ingestion in 5 seconds...")
                 time.sleep(5)
             else:
-                logger.error(
+                logger.exception(
                     "Maximum number of retries reached for package ingestion. Aborting."
                 )
                 # Abort ingestion if maximum retries reached
@@ -271,7 +271,7 @@ def ingest_nix_package(
                 wait(futures)
                 for i, f in enumerate(futures):
                     if f.exception():
-                        logger.error(
+                        logger.exception(
                             "Error occurred during edge ingestion "
                             "(Attempt %s, Edge: %s): %s",
                             attempt,
@@ -289,7 +289,7 @@ def ingest_nix_package(
                 click.echo("Retrying failed edge ingestion in 5 seconds...")
                 time.sleep(5)
             else:
-                logger.error(
+                logger.exception(
                     "Maximum number of retries reached for edge ingestion. Aborting."
                 )
                 # Abort ingestion if maximum retries reached

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -255,7 +255,7 @@ def ingest_nix_package(
                 click.echo("Retrying failed package ingestion in 5 seconds...")
                 time.sleep(5)
             else:
-                logger.exception(
+                click.echo(
                     "Maximum number of retries reached for package ingestion. Aborting."
                 )
                 # Abort ingestion if maximum retries reached
@@ -289,7 +289,7 @@ def ingest_nix_package(
                 click.echo("Retrying failed edge ingestion in 5 seconds...")
                 time.sleep(5)
             else:
-                logger.exception(
+                click.echo(
                     "Maximum number of retries reached for edge ingestion. Aborting."
                 )
                 # Abort ingestion if maximum retries reached

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -290,6 +290,22 @@ files = [
 ]
 
 [[package]]
+name = "errorhandler"
+version = "2.0.1"
+description = "A logging framework handler that tracks when messages above a certain level have been logged."
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "errorhandler-2.0.1-py2.py3-none-any.whl", hash = "sha256:dc6c54f5d9a4599e744b57aac2f925cce873188e9b02cae7c0eb120ee08a893f"},
+    {file = "errorhandler-2.0.1.tar.gz", hash = "sha256:7e578ad67af40845bfd044f71627a29f1fc436d53ccb058bbf1792ef31ab6163"},
+]
+
+[package.extras]
+build = ["pkginfo", "setuptools-git", "sphinx", "twine", "wheel"]
+test = ["coveralls", "nose", "nose-cov", "nose-fixes"]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.1.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -1405,4 +1421,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d6459ccd7e54f0108d89097a60f841637b5c72dd8c53385fb7ec8ad5df5b29c1"
+content-hash = "7e57fbef33499ceb73ac57d608622dd8c28eda6f6dbd32338f355f2f00a77d1c"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -29,6 +29,7 @@ uvicorn = {extras = ["standard"], version = "^0.21.1"}
 nixpkgs-graph-core = { version = "^1.0.0" }
 websockets = "^11.0.1"
 backoff = "^2.2.1"
+errorhandler = "^2.0.1"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This PR adds retry logic to the ingest_nix_graph function for handling failures during vertex and edge ingestion. It allows for multiple attempts to ingest failed items. 

Key changes include:
- Introduced a retries variable to specify the number of retry attempts.
- Implemented retry logic for vertex ingestion, logging errors and retrying failed vertices.
- Implemented retry logic for edge ingestion, logging errors and retrying failed edges.

These changes enhance the function's reliability by retrying failed ingestion attempts, ensuring successful ingestion of all items. The pull request also includes minor adjustments for improved logging and progress bar display.

Fixes #90 