### PR TITLE
Batch gremlin traversals

### DIFF
--- a/api/explorer/api/graph.py
+++ b/api/explorer/api/graph.py
@@ -29,7 +29,7 @@ class GraphElement(ABC, BaseModel):
         """Constructs a GraphElement from its properties
 
         Args:
-            element_map (Mapping[Any, Any]): A mapping of the elements properties,
+            element_map: A mapping of the elements properties,
                 for example as returned by a Gremlin elementMap() step.
 
         Raises:
@@ -137,25 +137,25 @@ class HasNativeBuiltInput(Edge):
 
 
 def insert_unique_directed_edge(
-    g: GraphTraversalSource,
+    g: GraphTraversal | GraphTraversalSource,
     edge: GraphElement,
     from_vertex: UniqueGraphElement,
     to_vertex: UniqueGraphElement,
-) -> None:
+) -> GraphTraversal:
     """Inserts an edge element using graph traversal source
 
     The created edge will be directed from `from_vertex` to `to_vertex`,
-       i.e.  `(from_vertex) - [edge] -> (to_vertex)`.
+       i.e.  `(from_vertex) - [edge] ->`.
 
     If either of the vertices do not exist this method will return without modifying
     the graph. It will also not create an edge if one with the same label already
     exists between the provided vertices.
 
     Args:
-        edge (GraphElement): the element to insert as an edge
-        from_vertex (UniqueGraphElement): the vertex at which the edge originates
-        to_vertex (UniqueGraphElement): the vertex at which the edge terminates
-        g (GraphTraversalSource): the graph traversal source to use for the insertion
+        edge: the element to insert as an edge
+        from_vertex: the vertex at which the edge originates
+        to_vertex: the vertex at which the edge terminates
+        g: the graph traversal to use for the insertion
     """
     properties = edge.dict()
     # Construct an anonymous traversal for inserting an edge with its properties
@@ -166,7 +166,7 @@ def insert_unique_directed_edge(
             property_name, property_value
         )
     # Main traversal
-    (
+    return (
         g.V()
         # Get the "from" vertex
         .has(from_vertex.label(), from_vertex.id_property_name(), from_vertex.get_id())
@@ -181,7 +181,6 @@ def insert_unique_directed_edge(
             # Otherwise, if no edge is found we create one
             insert_edge_traversal,
         )
-        .iterate()
     )
 
 
@@ -208,8 +207,8 @@ def insert_vertex(
     """Inserts a vertex element using graph traversal source
 
     Args:
-        e (GraphElement): the vertex element to insert
-        g (GraphTraversal): the graph traversal to use for the insertion
+        e: the vertex element to insert
+        g: the graph traversal to use for the insertion
     """
     return _traversal_insert_vertex(g, e)
 
@@ -224,13 +223,13 @@ def insert_unique_vertex(
     modifying the graph.
 
     Args:
-        e (UniqueGraphElement): the vertex element to insert
-        g (GraphTraversal): the graph traversal to use for the insertion
+        e: the vertex element to insert
+        g: the graph traversal to use for the insertion
     """
     return (
         g.V()
         .has(e.label(), e.id_property_name(), e.get_id())
-        # Trust me, it works (for inserting a unique vertex)
+        # Trust me, it works
         # See the examples here for more details:
         # https://docs.aws.amazon.com/neptune/latest/userguide/transactions-examples.html
         .fold()
@@ -247,8 +246,8 @@ def upsert_unique_vertex(
     already exist in the graph. If an existing vertex is found, updates its properties.
 
     Args:
-        e (UniqueGraphElement): the vertex element to insert or update
-        g (GraphTraversal): the graph traversal to use for the insertion
+        e: the vertex element to insert or update
+        g: the graph traversal to use for the insertion
     """
     # Construct a traversal for inserting the vertex if it does not exist
     insert_vertex_traversal = insert_unique_vertex(g, e)

--- a/api/explorer/api/graph.py
+++ b/api/explorer/api/graph.py
@@ -185,7 +185,10 @@ def insert_unique_directed_edge(
     )
 
 
-def _traversal_insert_vertex(g: GraphTraversal, e: GraphElement) -> GraphTraversal:
+def _traversal_insert_vertex(
+    g: GraphTraversal | GraphTraversalSource,
+    e: GraphElement,
+) -> GraphTraversal:
     # Extract dataclass properties
     properties = e.dict()
     traversal = g.add_v(e.label())
@@ -198,7 +201,10 @@ def _traversal_insert_vertex(g: GraphTraversal, e: GraphElement) -> GraphTravers
     return traversal
 
 
-def insert_vertex(g: GraphTraversal, e: GraphElement) -> GraphTraversal:
+def insert_vertex(
+    g: GraphTraversal | GraphTraversalSource,
+    e: GraphElement,
+) -> GraphTraversal:
     """Inserts a vertex element using graph traversal source
 
     Args:
@@ -208,7 +214,10 @@ def insert_vertex(g: GraphTraversal, e: GraphElement) -> GraphTraversal:
     return _traversal_insert_vertex(g, e)
 
 
-def insert_unique_vertex(g: GraphTraversal, e: UniqueGraphElement) -> GraphTraversal:
+def insert_unique_vertex(
+    g: GraphTraversal | GraphTraversalSource,
+    e: UniqueGraphElement,
+) -> GraphTraversal:
     """
     Inserts a uniquely identifiable vertex if a vertex corresponding to it does not
     already exist in the graph. If an existing vertex is found, returns without
@@ -229,7 +238,10 @@ def insert_unique_vertex(g: GraphTraversal, e: UniqueGraphElement) -> GraphTrave
     )
 
 
-def upsert_unique_vertex(g: GraphTraversal, e: UniqueGraphElement) -> GraphTraversal:
+def upsert_unique_vertex(
+    g: GraphTraversal | GraphTraversalSource,
+    e: UniqueGraphElement,
+) -> GraphTraversal:
     """
     Inserts a uniquely identifiable vertex if a vertex corresponding to it does not
     already exist in the graph. If an existing vertex is found, updates its properties.
@@ -241,7 +253,8 @@ def upsert_unique_vertex(g: GraphTraversal, e: UniqueGraphElement) -> GraphTrave
     # Construct a traversal for inserting the vertex if it does not exist
     insert_vertex_traversal = insert_unique_vertex(g, e)
 
-    # Append a traversal which updates all vertex properties to the traversal we construct above
+    # Append a traversal which updates all vertex properties to the traversal we
+    # construct above
     traversal = insert_vertex_traversal.V().has(
         e.label(), e.id_property_name(), e.get_id()
     )

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -98,13 +98,16 @@ def ingest_derivations(
             if build_input.output_path is not None
         ]
 
+        traversal = g.get_graph_traversal()
         # insert nodes
         for node in derivation_nodes:
             # insert if it does not exist, otherwise update properties
-            graph.upsert_unique_vertex(g, node)
+            traversal = graph.upsert_unique_vertex(traversal, node)
         for node in build_input_nodes:
             # insert build input nodes to allow creating the edge
-            graph.insert_unique_vertex(g, node)
+            traversal = graph.insert_unique_vertex(traversal, node)
+        # Now that the traversal has been constructed, let's evaluate it
+        traversal.iterate()
 
         # insert edges
         for derivation_node in derivation_nodes:

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -150,16 +150,26 @@ def ingest_derivations(
         " Server."
     ),
 )
+@click.option(
+    "--verbose",
+    is_flag=True,
+)
 def main(
     infile: IO[str],
     gremlin_server: str,
     gremlin_source: str,
+    verbose: bool,
 ):
     """
     Ingests from INFILE to a Gremlin Server.
 
     INFILE should be a JSONL stream of derivations as defined by `model.Derivation`.
     """
+    logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
+    logging.getLogger("websockets.client").setLevel(logging.WARNING)
+    logging.getLogger("gremlinpython").setLevel(
+        logging.INFO if verbose else logging.WARNING
+    )
     with closing(
         default_remote_connection(
             gremlin_server,
@@ -171,6 +181,4 @@ def main(
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    logging.getLogger("gremlinpython").setLevel(logging.WARNING)
     main()

--- a/api/explorer/api/ingest.py
+++ b/api/explorer/api/ingest.py
@@ -98,7 +98,9 @@ def ingest_derivations(
             if build_input.output_path is not None
         ]
 
+        # share same traversal to run all operations at once
         traversal = g.get_graph_traversal()
+
         # insert nodes
         for node in derivation_nodes:
             # insert if it does not exist, otherwise update properties
@@ -107,7 +109,6 @@ def ingest_derivations(
             # insert build input nodes to allow creating the edge
             traversal = graph.insert_unique_vertex(traversal, node)
         # Now that the traversal has been constructed, let's evaluate it
-        traversal.iterate()
 
         # insert edges
         for derivation_node in derivation_nodes:
@@ -118,13 +119,14 @@ def ingest_derivations(
                 edge: graph.Edge = _edge_from_build_input_type(
                     build_input.build_input_type
                 )
-                graph.insert_unique_directed_edge(
-                    g=g,
+                traversal = graph.insert_unique_directed_edge(
+                    g=traversal,
                     edge=edge,
                     from_vertex=derivation_node,
                     to_vertex=build_input_node,
                 )
 
+        traversal.iterate()
         logger.info("%s", derivation.output_path)
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -34,7 +34,9 @@ def populated_graph_connection(empty_graph_connection):
 
     # Add edges between them
     for edge, from_vertex, to_vertex in EDGES:
-        graph_traversal = insert_unique_directed_edge(graph_traversal, edge, from_vertex, to_vertex)
+        graph_traversal = insert_unique_directed_edge(
+            graph_traversal, edge, from_vertex, to_vertex
+        )
 
     graph_traversal.iterate()
     yield empty_graph_connection

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -31,9 +31,10 @@ def populated_graph_connection(empty_graph_connection):
     # Add nodes
     for drv in DUMMY_DERIVATIONS:
         graph_traversal = insert_unique_vertex(graph_traversal, drv)
-    graph_traversal.iterate()
 
     # Add edges between them
     for edge, from_vertex, to_vertex in EDGES:
-        insert_unique_directed_edge(g, edge, from_vertex, to_vertex)
+        graph_traversal = insert_unique_directed_edge(graph_traversal, edge, from_vertex, to_vertex)
+
+    graph_traversal.iterate()
     yield empty_graph_connection

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -26,8 +26,13 @@ def empty_graph_connection():
 @pytest.fixture
 def populated_graph_connection(empty_graph_connection):
     g = traversal().with_remote(empty_graph_connection)
+    graph_traversal = g.get_graph_traversal()
+
+    # Add nodes
     for drv in DUMMY_DERIVATIONS:
-        insert_unique_vertex(g, drv)
+        graph_traversal = insert_unique_vertex(graph_traversal, drv)
+    graph_traversal.iterate()
+
     # Add edges between them
     for edge, from_vertex, to_vertex in EDGES:
         insert_unique_directed_edge(g, edge, from_vertex, to_vertex)

--- a/api/tests/test_graph.py
+++ b/api/tests/test_graph.py
@@ -120,7 +120,7 @@ def test_unit_insert_unique_directed_edge_both_vertices_exist(
         edge=DummyEdgeNoProps(),
         from_vertex=vertex1,
         to_vertex=vertex2,
-    )
+    ).iterate()
     assert g.E().count().to_list() == [1]
 
 
@@ -141,7 +141,7 @@ def test_unit_insert_unique_directed_edge_does_nothing_if_from_vertex_not_found(
         edge=DummyEdgeNoProps(),
         from_vertex=missing_vertex,
         to_vertex=vertex,
-    )
+    ).iterate()
     assert g.E().count().to_list() == [0]
 
 
@@ -162,7 +162,7 @@ def test_unit_insert_unique_directed_edge_does_nothing_if_to_vertex_not_found(
         edge=DummyEdgeNoProps(),
         from_vertex=vertex,
         to_vertex=missing_vertex,
-    )
+    ).iterate()
     assert g.E().count().to_list() == [0]
 
 
@@ -184,14 +184,14 @@ def test_unit_insert_unique_directed_edge_does_not_create_duplicates(
         edge=DummyEdgeNoProps(),
         from_vertex=vertex1,
         to_vertex=vertex2,
-    )
+    ).iterate()
     # Attempt to insert it again
     insert_unique_directed_edge(
         g=g,
         edge=DummyEdgeNoProps(),
         from_vertex=vertex1,
         to_vertex=vertex2,
-    )
+    ).iterate()
 
     assert g.E().count().to_list() == [1]
 
@@ -215,7 +215,7 @@ def test_unit_insert_unique_directed_edge_created_edge_properties(
         edge=edge,
         from_vertex=vertex1,
         to_vertex=vertex2,
-    )
+    ).iterate()
     # Attempt to read the edge's properties
     element_maps = cast(
         Mapping[Any, Any], g.E().hasLabel(edge.label()).element_map().to_list()

--- a/api/tests/test_graph.py
+++ b/api/tests/test_graph.py
@@ -63,7 +63,7 @@ def test_unit_insert_vertex(empty_graph_connection: DriverRemoteConnection):
 
     g = traversal().withRemote(empty_graph_connection)
     element = DummyGraphElement()
-    insert_vertex(g, element)
+    insert_vertex(g, element).iterate()
     assert g.V().count().to_list() == [1]
 
 
@@ -74,8 +74,8 @@ def test_unit_insert_vertex_allows_duplicates(
 
     g = traversal().withRemote(empty_graph_connection)
     element = DummyGraphElement()
-    insert_vertex(g, element)
-    insert_vertex(g, element)
+    insert_vertex(g, element).iterate()
+    insert_vertex(g, element).iterate()
     assert g.V().count().to_list() == [2]
 
 
@@ -86,7 +86,7 @@ def test_unit_insert_unique_vertex_creates_when_one_does_not_exist(
 
     g = traversal().withRemote(empty_graph_connection)
     element = DummyUniqueGraphElement(unique_property="some-unique-value-1")
-    insert_unique_vertex(g, element)
+    insert_unique_vertex(g, element).iterate()
     assert g.V().count().to_list() == [1]
 
 
@@ -97,8 +97,8 @@ def test_unit_insert_unique_vertex_does_not_duplicate_vertex(
 
     g = traversal().withRemote(empty_graph_connection)
     element = DummyUniqueGraphElement(unique_property="some-unique-value-1")
-    insert_unique_vertex(g, element)
-    insert_unique_vertex(g, element)
+    insert_unique_vertex(g, element).iterate()
+    insert_unique_vertex(g, element).iterate()
     assert g.V().count().to_list() == [1]
 
 
@@ -111,8 +111,8 @@ def test_unit_insert_unique_directed_edge_both_vertices_exist(
     g = traversal().withRemote(empty_graph_connection)
     vertex1 = DummyUniqueGraphElement(unique_property="some-unique-value-1")
     vertex2 = DummyUniqueGraphElement(unique_property="some-unique-value-2")
-    insert_unique_vertex(g, vertex1)
-    insert_unique_vertex(g, vertex2)
+    insert_unique_vertex(g, vertex1).iterate()
+    insert_unique_vertex(g, vertex2).iterate()
 
     # Create the edge
     insert_unique_directed_edge(
@@ -175,8 +175,8 @@ def test_unit_insert_unique_directed_edge_does_not_create_duplicates(
     g = traversal().withRemote(empty_graph_connection)
     vertex1 = DummyUniqueGraphElement(unique_property="some-unique-value-1")
     vertex2 = DummyUniqueGraphElement(unique_property="some-unique-value-2")
-    insert_unique_vertex(g, vertex1)
-    insert_unique_vertex(g, vertex2)
+    insert_unique_vertex(g, vertex1).iterate()
+    insert_unique_vertex(g, vertex2).iterate()
 
     # Create the edge
     insert_unique_directed_edge(
@@ -205,8 +205,8 @@ def test_unit_insert_unique_directed_edge_created_edge_properties(
     g = traversal().withRemote(empty_graph_connection)
     vertex1 = DummyUniqueGraphElement(unique_property="some-unique-value-1")
     vertex2 = DummyUniqueGraphElement(unique_property="some-unique-value-2")
-    insert_unique_vertex(g, vertex1)
-    insert_unique_vertex(g, vertex2)
+    insert_unique_vertex(g, vertex1).iterate()
+    insert_unique_vertex(g, vertex2).iterate()
 
     # Create the edge
     edge = DummyEdge(prop1="foo", prop2=1)


### PR DESCRIPTION
Upon ingestion, we read each JSON line, we parse it and create the proper nodes and edges in the graph database.
Each insertion/update was done in its own traversal, which had an impact on ingestion speed.

This PR proposes to put together the operations to do to ingest a derivation in a single, shared traversal, to reduce the count of transactions and boost performances.