### PR TITLE
Add structured logging to ingestion

### DIFF
--- a/docker/sqlg/docker-entrypoint.sh
+++ b/docker/sqlg/docker-entrypoint.sh
@@ -18,4 +18,4 @@ fi
 IP=$(ip -o -4 addr list eth0 | perl -n -e 'if (m{inet\s([\d\.]+)\/\d+\s}xms) { print $1 }')
 sed -i "s|^host:.*|host: $IP|" $CONF_FILE
 
-/gremlin-server/bin/gremlin-server.sh console
+JAVA_OPTIONS="-Xmx2G" /gremlin-server/bin/gremlin-server.sh console

--- a/docker/sqlg/gremlin-server.yaml
+++ b/docker/sqlg/gremlin-server.yaml
@@ -1,5 +1,6 @@
 host: localhost
 port: 8182
+# Time in milliseconds that an evaluation is allowed to run and its results potentially transformed. Set to zero to have no timeout set.
 evaluationTimeout: 0
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
 graphs: { graph: /secrets/sqlg.properties }

--- a/docker/sqlg/gremlin-server.yaml
+++ b/docker/sqlg/gremlin-server.yaml
@@ -1,5 +1,6 @@
 host: localhost
 port: 8182
+evaluationTimeout: 0
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
 graphs: { graph: /secrets/sqlg.properties }
 scriptEngines:


### PR DESCRIPTION
Help monitor ingestion with structured logging.

Also, do not stop the whole ingestion when there is an error.
Also, remove the execution timeout on sqlg.